### PR TITLE
Add support for measuring DTLS server metrics with Micrometer

### DIFF
--- a/kotlin-mbedtls-metrics/build.gradle.kts
+++ b/kotlin-mbedtls-metrics/build.gradle.kts
@@ -19,9 +19,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
     testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
-    testImplementation("ch.qos.logback:logback-classic:1.3.0")
-    testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
-    testImplementation("io.mockk:mockk:1.13.4")
 }
 
 java {

--- a/kotlin-mbedtls-metrics/build.gradle.kts
+++ b/kotlin-mbedtls-metrics/build.gradle.kts
@@ -1,0 +1,44 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.7.22"
+    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
+    id("com.adarshr.test-logger") version "3.2.0"
+    id("io.gitlab.arturbosch.detekt") version "1.22.0"
+}
+
+dependencies {
+    api(project(":kotlin-mbedtls"))
+
+    api(platform("org.jetbrains.kotlin:kotlin-bom"))
+    api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    implementation("io.micrometer:micrometer-core:1.10.4")
+
+    // TESTS
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
+    testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
+    testImplementation("ch.qos.logback:logback-classic:1.3.0")
+    testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
+    testImplementation("io.mockk:mockk:1.13.4")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+detekt {
+    source = files("src/main/kotlin")
+    config = files("../detekt.yml")
+    buildUponDefaultConfig = true
+}

--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -26,28 +26,28 @@ import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
 
 class DtlsServerMetricsCallbacks(private val registry: MeterRegistry, metricsPrefix: String = "dtls.server") : DtlsServer.DtlsSessionLifecycleCallbacks {
-    private val handshakesInitiated = registry.counter("${metricsPrefix}.handshakes.initiated")
-    private val handshakesSucceeded = registry.timer("${metricsPrefix}.handshakes.succeeded")
-    private val handshakesFailedBuilder = Counter.builder("${metricsPrefix}.handshakes.failed")
-    private val handshakesExpired = registry.counter("${metricsPrefix}.handshakes.expired")
-    private val sessionsStartedBuilder = Counter.builder("${metricsPrefix}.sessions.started")
-    private val sessionsClosed = registry.counter("${metricsPrefix}.sessions.closed")
-    private val sessionsFailedBuilder = Counter.builder("${metricsPrefix}.sessions.failed")
-    private val sessionsExpired = registry.counter("${metricsPrefix}.sessions.expired")
-    private val sessionsReloaded = registry.counter("${metricsPrefix}.sessions.reloaded")
+    private val handshakesInitiated = registry.counter("$metricsPrefix.handshakes.initiated")
+    private val handshakesSucceeded = registry.timer("$metricsPrefix.handshakes.succeeded")
+    private val handshakesFailedBuilder = Counter.builder("$metricsPrefix.handshakes.failed")
+    private val handshakesExpired = registry.counter("$metricsPrefix.handshakes.expired")
+    private val sessionsStartedBuilder = Counter.builder("$metricsPrefix.sessions.started")
+    private val sessionsClosed = registry.counter("$metricsPrefix.sessions.closed")
+    private val sessionsFailedBuilder = Counter.builder("$metricsPrefix.sessions.failed")
+    private val sessionsExpired = registry.counter("$metricsPrefix.sessions.expired")
+    private val sessionsReloaded = registry.counter("$metricsPrefix.sessions.reloaded")
 
     override fun handshakeStarted(adr: InetSocketAddress, ctx: SslHandshakeContext) {
         handshakesInitiated.increment()
     }
 
-    override fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when(reason) {
+    override fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when (reason) {
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED ->
             handshakesSucceeded.record(System.currentTimeMillis() - ctx.startTimestamp, TimeUnit.MILLISECONDS)
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED ->
             if (throwable is HelloVerifyRequired) {
                 // Skip HelloVerifyRequired handshake states
             } else {
-                val reasonTag = when(throwable) {
+                val reasonTag = when (throwable) {
                     null -> "n/a"
                     else -> throwable::class.toString()
                 }
@@ -64,9 +64,9 @@ class DtlsServerMetricsCallbacks(private val registry: MeterRegistry, metricsPre
         sessionsStartedBuilder.tag("suite", ctx.cipherSuite).register(registry).increment()
     }
 
-    override fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when(reason) {
+    override fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when (reason) {
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED -> {
-            val reasonTag = when(throwable) {
+            val reasonTag = when (throwable) {
                 null -> "n/a"
                 else -> throwable::class.toString()
             }

--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.opencoap.ssl.transport.metrics.micrometer
 
 import io.micrometer.core.instrument.Counter

--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -63,11 +63,7 @@ class DtlsServerMetricsCallbacks(
             if (throwable is HelloVerifyRequired) {
                 // Skip HelloVerifyRequired handshake states
             } else {
-                val reasonTag = when (throwable) {
-                    null -> "n/a"
-                    else -> throwable::class.toString()
-                }
-                handshakesFailedBuilder.tag("reason", reasonTag).register(registry).increment()
+                handshakesFailedBuilder.reasonTag(throwable).register(registry).increment()
             }
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.EXPIRED ->
             handshakesExpired.increment()
@@ -82,11 +78,7 @@ class DtlsServerMetricsCallbacks(
 
     override fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when (reason) {
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED -> {
-            val reasonTag = when (throwable) {
-                null -> "n/a"
-                else -> throwable::class.toString()
-            }
-            sessionsFailedBuilder.tag("reason", reasonTag).register(registry).increment()
+            sessionsFailedBuilder.reasonTag(throwable).register(registry).increment()
         }
         DtlsServer.DtlsSessionLifecycleCallbacks.Reason.CLOSED ->
             sessionsClosed.increment()
@@ -94,4 +86,13 @@ class DtlsServerMetricsCallbacks(
             sessionsExpired.increment()
         else -> {}
     }
+}
+
+private fun Counter.Builder.reasonTag(throwable: Throwable?): Counter.Builder {
+    val reason = when (throwable) {
+        null -> "n/a"
+        else -> throwable::class.qualifiedName ?: "n/a"
+    }
+
+    return this.tag("reason", reason)
 }

--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -1,0 +1,65 @@
+package org.opencoap.ssl.transport.metrics.micrometer
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.opencoap.ssl.HelloVerifyRequired
+import org.opencoap.ssl.SslHandshakeContext
+import org.opencoap.ssl.SslSession
+import org.opencoap.ssl.transport.DtlsServer
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+class DtlsServerMetricsCallbacks(private val registry: MeterRegistry, metricsPrefix: String = "dtls.server") : DtlsServer.DtlsSessionLifecycleCallbacks {
+    private val handshakesInitiated = registry.counter("${metricsPrefix}.handshakes.initiated")
+    private val handshakesSucceeded = registry.timer("${metricsPrefix}.handshakes.succeeded")
+    private val handshakesFailedBuilder = Counter.builder("${metricsPrefix}.handshakes.failed")
+    private val handshakesExpired = registry.counter("${metricsPrefix}.handshakes.expired")
+    private val sessionsStartedBuilder = Counter.builder("${metricsPrefix}.sessions.started")
+    private val sessionsClosed = registry.counter("${metricsPrefix}.sessions.closed")
+    private val sessionsFailedBuilder = Counter.builder("${metricsPrefix}.sessions.failed")
+    private val sessionsExpired = registry.counter("${metricsPrefix}.sessions.expired")
+    private val sessionsReloaded = registry.counter("${metricsPrefix}.sessions.reloaded")
+
+    override fun handshakeStarted(adr: InetSocketAddress, ctx: SslHandshakeContext) {
+        handshakesInitiated.increment()
+    }
+
+    override fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when(reason) {
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED ->
+            handshakesSucceeded.record(System.currentTimeMillis() - ctx.startTimestamp, TimeUnit.MILLISECONDS)
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED ->
+            if (throwable is HelloVerifyRequired) {
+                // Skip HelloVerifyRequired handshake states
+            } else {
+                val reasonTag = when(throwable) {
+                    null -> "n/a"
+                    else -> throwable::class.toString()
+                }
+                handshakesFailedBuilder.tag("reason", reasonTag).register(registry).increment()
+            }
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.EXPIRED ->
+            handshakesExpired.increment()
+        else -> {}
+    }
+
+    override fun sessionStarted(adr: InetSocketAddress, ctx: SslSession) = if (ctx.reloaded) {
+        sessionsReloaded.increment()
+    } else {
+        sessionsStartedBuilder.tag("suite", ctx.cipherSuite).register(registry).increment()
+    }
+
+    override fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: DtlsServer.DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when(reason) {
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED -> {
+            val reasonTag = when(throwable) {
+                null -> "n/a"
+                else -> throwable::class.toString()
+            }
+            sessionsFailedBuilder.tag("reason", reasonTag).register(registry).increment()
+        }
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.CLOSED ->
+            sessionsClosed.increment()
+        DtlsServer.DtlsSessionLifecycleCallbacks.Reason.EXPIRED ->
+            sessionsExpired.increment()
+        else -> {}
+    }
+}

--- a/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
+++ b/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
@@ -69,7 +69,7 @@ class DtlsServerMetricsCallbacksTest {
 
     @Test
     fun `should report DTLS server metrics for happy scenario`() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = metricsCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(metricsCallbacks)).listen(echoHandler)
 
         val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
         await.untilAsserted {
@@ -91,7 +91,7 @@ class DtlsServerMetricsCallbacksTest {
 
     @Test
     fun `should report DTLS server metrics for expiring sessions`() {
-        server = DtlsServer.create(conf, sessionStore = sessionStore, lifecycleCallbacks = metricsCallbacks, expireAfter = Duration.ofMillis(10)).listen(echoHandler)
+        server = DtlsServer.create(conf, sessionStore = sessionStore, lifecycleCallbacks = listOf(metricsCallbacks), expireAfter = Duration.ofMillis(10)).listen(echoHandler)
 
         val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
         client.send("foo")

--- a/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
+++ b/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl.transport.metrics.micrometer
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.opencoap.ssl.EmptyCidSupplier
+import org.opencoap.ssl.PskAuth
+import org.opencoap.ssl.RandomCidSupplier
+import org.opencoap.ssl.SslConfig
+import org.opencoap.ssl.transport.BytesPacket
+import org.opencoap.ssl.transport.DtlsServer
+import org.opencoap.ssl.transport.DtlsTransmitter
+import org.opencoap.ssl.transport.HashMapSessionStore
+import org.opencoap.ssl.transport.Packet
+import org.opencoap.ssl.transport.listen
+import java.util.concurrent.TimeUnit
+import java.time.Duration
+import java.util.function.Consumer
+
+class DtlsServerMetricsCallbacksTest {
+    private val psk = PskAuth("dupa", byteArrayOf(1))
+    private val conf: SslConfig = SslConfig.server(psk, cidSupplier = RandomCidSupplier(6))
+    private val clientConfig = SslConfig.client(psk, cidSupplier = EmptyCidSupplier)
+    private val meterRegistry = SimpleMeterRegistry()
+    private val metricsCallbacks = DtlsServerMetricsCallbacks(meterRegistry)
+    private val sessionStore = HashMapSessionStore()
+
+    private lateinit var server: DtlsServer
+
+    private val echoHandler: Consumer<BytesPacket> = Consumer<BytesPacket> { packet ->
+        val msg = packet.buffer.decodeToString()
+        if (msg == "error") {
+            throw Exception("error")
+        } else if (msg.startsWith("Authenticate:")) {
+            server.setSessionAuthenticationContext(packet.peerAddress, msg.substring(12))
+            server.send(Packet("OK".encodeToByteArray(), packet.peerAddress))
+        } else {
+            val ctx = (packet.sessionContext.authentication ?: "")
+            server.send(packet.map { it.plus(":resp$ctx".encodeToByteArray()) })
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.close()
+        conf.close()
+        clientConfig.close()
+        meterRegistry.clear()
+        sessionStore.clear()
+    }
+
+    @Test
+    fun `should report DTLS server metrics for happy scenario`() {
+        server = DtlsServer.create(conf, lifecycleCallbacks = metricsCallbacks).listen(echoHandler)
+
+        val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
+        await.untilAsserted {
+            assertEquals(1, server.numberOfSessions())
+        }
+
+        client.closeNotify()
+
+        assertEquals(2, meterRegistry.find("dtls.server.handshakes.initiated").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.handshakes.succeeded").timer()?.count()?.toInt())
+        assertEquals(null, meterRegistry.find("dtls.server.handshakes.failed").counter()?.count()?.toInt())
+        assertEquals(0, meterRegistry.find("dtls.server.handshakes.expired").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.started").tag("suite") { it.isNotEmpty() }.counter()?.count()?.toInt())
+        assertEquals(null, meterRegistry.find("dtls.server.sessions.failed").counter()?.count()?.toInt())
+        assertEquals(0, meterRegistry.find("dtls.server.sessions.expired").counter()?.count()?.toInt())
+        assertEquals(0, meterRegistry.find("dtls.server.sessions.reloaded").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.closed").counter()?.count()?.toInt())
+    }
+
+    @Test
+    fun `should report DTLS server metrics for expiring sessions`() {
+        server = DtlsServer.create(conf, sessionStore = sessionStore, lifecycleCallbacks = metricsCallbacks, expireAfter = Duration.ofMillis(10)).listen(echoHandler)
+
+        val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
+        client.send("foo")
+
+        await.atMost(Duration.ofSeconds(1)).untilAsserted {
+            assertEquals(0, server.numberOfSessions())
+        }
+
+        client.send("bar")
+
+        assertEquals(2, meterRegistry.find("dtls.server.handshakes.initiated").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.handshakes.succeeded").timer()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.started").tag("suite") { it.isNotEmpty() }.counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.expired").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.reloaded").counter()?.count()?.toInt())
+    }
+}

--- a/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
+++ b/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
@@ -75,7 +75,7 @@ class DtlsServerMetricsCallbacksTest {
 
     @Test
     fun `should report DTLS server metrics for happy scenario`() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(metricsCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = metricsCallbacks).listen(echoHandler)
 
         val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
         await.untilAsserted {
@@ -101,7 +101,7 @@ class DtlsServerMetricsCallbacksTest {
 
     @Test
     fun `should report DTLS server metrics for expiring sessions`() {
-        server = DtlsServer.create(conf, sessionStore = sessionStore, lifecycleCallbacks = listOf(metricsCallbacks), expireAfter = Duration.ofMillis(200)).listen(echoHandler)
+        server = DtlsServer.create(conf, sessionStore = sessionStore, lifecycleCallbacks = metricsCallbacks, expireAfter = Duration.ofMillis(200)).listen(echoHandler)
 
         val client = DtlsTransmitter.connect(server, clientConfig).get(5, TimeUnit.SECONDS)
         client.send("foo")
@@ -125,7 +125,7 @@ class DtlsServerMetricsCallbacksTest {
 
     @Test
     fun `should report DTLS server metrics for handshake errors`() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(metricsCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = metricsCallbacks).listen(echoHandler)
         val cliChannel: DatagramChannel = DatagramChannel.open()
             .connect(InetSocketAddress(InetAddress.getLocalHost(), server.localPort()))
 
@@ -143,7 +143,7 @@ class DtlsServerMetricsCallbacksTest {
     @Test
     fun `should report DTLS server metrics for session errors`() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(metricsCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = metricsCallbacks).listen(echoHandler)
         val dest = InetSocketAddress(InetAddress.getLocalHost(), server.localPort())
         val transport = DatagramChannelAdapter.connect(dest, 0)
         val client = DtlsTransmitter.connect(dest, clientConfig, transport).get(5, TimeUnit.SECONDS)

--- a/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
+++ b/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
@@ -19,7 +19,7 @@ package org.opencoap.ssl.transport.metrics.micrometer
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.opencoap.ssl.EmptyCidSupplier
 import org.opencoap.ssl.PskAuth
@@ -31,8 +31,8 @@ import org.opencoap.ssl.transport.DtlsTransmitter
 import org.opencoap.ssl.transport.HashMapSessionStore
 import org.opencoap.ssl.transport.Packet
 import org.opencoap.ssl.transport.listen
-import java.util.concurrent.TimeUnit
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
 class DtlsServerMetricsCallbacksTest {

--- a/kotlin-mbedtls/build.gradle.kts
+++ b/kotlin-mbedtls/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
     testImplementation("ch.qos.logback:logback-classic:1.3.0")
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
+    testImplementation("io.mockk:mockk:1.13.4")
 }
 
 java {

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslConfig.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslConfig.kt
@@ -94,7 +94,7 @@ class SslConfig(
         mbedtls_ssl_context_load(sslContext, session, session.size).verify()
         mbedtls_ssl_set_bio(sslContext, Pointer.NULL, SendCallback, null, ReceiveCallback)
 
-        return SslSession(this, sslContext, cid).also {
+        return SslSession(this, sslContext, cid, true).also {
             logger.info("[{}] Reconnected {}", peerAddress, it)
         }
     }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -67,7 +67,7 @@ class SslHandshakeContext internal constructor(
     private val peerAdr: InetSocketAddress,
 ) : SslContext {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val startTimestamp: Long = System.currentTimeMillis()
+    val startTimestamp: Long = System.currentTimeMillis()
     private var stepTimeout: Duration = Duration.ZERO
 
     fun step(send: (ByteBuffer) -> Unit): SslContext {
@@ -108,6 +108,7 @@ class SslSession internal constructor(
     private val conf: SslConfig, // keep in memory to prevent GC
     private val sslContext: Memory,
     private val cid: ByteArray?,
+    val reloaded: Boolean = false,
 ) : SslContext, Closeable {
 
     val peerCid: ByteArray? = readPeerCid()

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
@@ -24,7 +24,6 @@ open class SslException(message: String) : Exception(message) {
     companion object {
         fun from(error: Int): SslException = when (error) {
             MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY -> CloseNotifyException
-            MbedtlsApi.MBEDTLS_ERR_SSL_TIMEOUT -> OperationTimeoutException
             else -> SslException(String.format(Locale.US, "%s [-0x%04X]", translateError(error), -error))
         }
 
@@ -38,4 +37,3 @@ open class SslException(message: String) : Exception(message) {
 
 object HelloVerifyRequired : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED))
 object CloseNotifyException : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY))
-object OperationTimeoutException : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_TIMEOUT))

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
@@ -22,11 +22,10 @@ import java.util.Locale
 open class SslException(message: String) : Exception(message) {
 
     companion object {
-        fun from(error: Int): SslException {
-            if (error == MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-                return CloseNotifyException
-            }
-            return SslException(String.format(Locale.US, "%s [-0x%04X]", translateError(error), -error))
+        fun from(error: Int): SslException = when (error) {
+            MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY -> CloseNotifyException
+            MbedtlsApi.MBEDTLS_ERR_SSL_TIMEOUT -> OperationTimeoutException
+            else -> SslException(String.format(Locale.US, "%s [-0x%04X]", translateError(error), -error))
         }
 
         internal fun translateError(error: Int): String {
@@ -39,3 +38,4 @@ open class SslException(message: String) : Exception(message) {
 
 object HelloVerifyRequired : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED))
 object CloseNotifyException : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY))
+object OperationTimeoutException : SslException(translateError(MbedtlsApi.MBEDTLS_ERR_SSL_TIMEOUT))

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -311,14 +311,4 @@ class DtlsServer(
             sessionContext = sessionContext.copy(authentication = authentication)
         }
     }
-
-    interface DtlsSessionLifecycleCallbacks {
-        enum class Reason {
-            SUCCEEDED, FAILED, CLOSED, EXPIRED
-        }
-        fun handshakeStarted(adr: InetSocketAddress, ctx: SslHandshakeContext) = Unit
-        fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: Reason, throwable: Throwable? = null) = Unit
-        fun sessionStarted(adr: InetSocketAddress, ctx: SslSession) = Unit
-        fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: Reason, throwable: Throwable? = null) = Unit
-    }
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -40,6 +40,7 @@ class DtlsServer(
     private val sslConfig: SslConfig,
     private val expireAfter: Duration = Duration.ofSeconds(60),
     private val sessionStore: SessionStore = NoOpsSessionStore,
+    private val lifecycleCallbacks: DtlsSessionLifecycleCallbacks = object : DtlsSessionLifecycleCallbacks {}
 ) : Transport<BytesPacket> {
 
     companion object {
@@ -51,10 +52,11 @@ class DtlsServer(
             config: SslConfig,
             listenPort: Int = 0,
             expireAfter: Duration = Duration.ofSeconds(60),
-            sessionStore: SessionStore = NoOpsSessionStore
+            sessionStore: SessionStore = NoOpsSessionStore,
+            lifecycleCallbacks: DtlsSessionLifecycleCallbacks = object : DtlsSessionLifecycleCallbacks {}
         ): DtlsServer {
             val channel = DatagramChannelAdapter.open(listenPort)
-            return DtlsServer(channel, config, expireAfter, sessionStore)
+            return DtlsServer(channel, config, expireAfter, sessionStore, lifecycleCallbacks)
         }
     }
 
@@ -101,6 +103,7 @@ class DtlsServer(
                 @Suppress("UnsafeCallOnNullableType") // smart casting does not work for lazy delegate
                 loadSession(cid!!, adr).thenCompose { isLoaded ->
                     if (isLoaded) {
+                        lifecycleCallbacks.sessionStarted(adr, DtlsSessionLifecycleCallbacks.SessionState.RELOADED)
                         handleReceived(adr, copyBuf, timeout)
                     } else {
                         receive(timeout)
@@ -186,8 +189,12 @@ class DtlsServer(
 
     private inner class DtlsHandshake(
         private val ctx: SslHandshakeContext,
-        peerAddress: InetSocketAddress
+        peerAddress: InetSocketAddress,
     ) : DtlsState(peerAddress) {
+
+        init {
+            lifecycleCallbacks.handshakeStarted(peerAddress)
+        }
 
         private fun send(buf: ByteBuffer) {
             transport.send(Packet(buf, peerAddress))
@@ -208,21 +215,26 @@ class DtlsServer(
                         }
                     }
 
-                    is SslSession ->
+                    is SslSession -> {
+                        lifecycleCallbacks.handshakeFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.SUCCEED)
                         sessions[peerAddress] = DtlsSession(newCtx, peerAddress)
+                    }
                 }
-            } catch (ex: HelloVerifyRequired) {
-                closeAndRemove()
-            } catch (ex: SslException) {
-                logger.warn("[{}] DTLS failed: {}", peerAddress, ex.message)
-                closeAndRemove()
             } catch (ex: Exception) {
-                logger.error(ex.toString(), ex)
+                when (ex) {
+                    is HelloVerifyRequired -> {}
+                    is SslException ->
+                        logger.warn("[{}] DTLS failed: {}", peerAddress, ex.message)
+                    else ->
+                        logger.error(ex.toString(), ex)
+                }
+                lifecycleCallbacks.handshakeFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
                 closeAndRemove()
             }
         }
 
         fun timeout() {
+            lifecycleCallbacks.handshakeFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             closeAndRemove()
             logger.warn("[{}] DTLS handshake expired", peerAddress)
         }
@@ -239,6 +251,10 @@ class DtlsServer(
             peerCertificateSubject = ctx.peerCertificateSubject
         )
     ) : DtlsState(peerAddress) {
+
+        init {
+            lifecycleCallbacks.sessionStarted(peerAddress)
+        }
 
         override fun storeAndClose0() {
             if (ctx.ownCid != null) {
@@ -264,9 +280,12 @@ class DtlsServer(
                 return plainBuf
             } catch (ex: CloseNotifyException) {
                 logger.info("[{}] DTLS received close notify", peerAddress)
+                lifecycleCallbacks.sessionFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.CLOSED)
             } catch (ex: SslException) {
                 logger.warn("[{}] DTLS failed: {}", peerAddress, ex.message)
+                lifecycleCallbacks.sessionFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
             }
+
             closeAndRemove()
             return byteArrayOf()
         }
@@ -276,12 +295,14 @@ class DtlsServer(
                 return ctx.encrypt(plainPacket)
             } catch (ex: SslException) {
                 logger.warn("[{}] DTLS failed: {}", peerAddress, ex.message)
+                lifecycleCallbacks.sessionFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
                 closeAndRemove()
                 throw ex
             }
         }
 
         fun timeout() {
+            lifecycleCallbacks.sessionFinished(peerAddress, DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             sessions.remove(peerAddress, this)
             logger.info("[{}] DTLS connection expired", peerAddress)
             storeAndClose()
@@ -290,5 +311,18 @@ class DtlsServer(
         fun setAuthenticationContext(authentication: String?) {
             sessionContext = sessionContext.copy(authentication = authentication)
         }
+    }
+
+    interface DtlsSessionLifecycleCallbacks {
+        enum class Reason {
+            SUCCEED, FAILED, CLOSED, EXPIRED
+        }
+        enum class SessionState {
+            NEW, RELOADED
+        }
+        fun handshakeStarted(adr: InetSocketAddress) = Unit
+        fun handshakeFinished(adr: InetSocketAddress, reason: Reason, throwable: Throwable? = null) = Unit
+        fun sessionStarted(adr: InetSocketAddress, state: SessionState = SessionState.NEW) = Unit
+        fun sessionFinished(adr: InetSocketAddress, reason: Reason, throwable: Throwable? = null) = Unit
     }
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
@@ -16,16 +16,14 @@
 
 package org.opencoap.ssl.transport
 
-import org.opencoap.ssl.SslHandshakeContext
-import org.opencoap.ssl.SslSession
 import java.net.InetSocketAddress
 
 interface DtlsSessionLifecycleCallbacks {
     enum class Reason {
         SUCCEEDED, FAILED, CLOSED, EXPIRED
     }
-    fun handshakeStarted(adr: InetSocketAddress, ctx: SslHandshakeContext) = Unit
-    fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: Reason, throwable: Throwable? = null) = Unit
-    fun sessionStarted(adr: InetSocketAddress, ctx: SslSession) = Unit
-    fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: Reason, throwable: Throwable? = null) = Unit
+    fun handshakeStarted(adr: InetSocketAddress) = Unit
+    fun handshakeFinished(adr: InetSocketAddress, hanshakeStartTimestamp: Long, reason: Reason, throwable: Throwable? = null) = Unit
+    fun sessionStarted(adr: InetSocketAddress, cipherSuite: String, reloaded: Boolean) = Unit
+    fun sessionFinished(adr: InetSocketAddress, reason: Reason, throwable: Throwable? = null) = Unit
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl.transport
+
+import org.opencoap.ssl.SslHandshakeContext
+import org.opencoap.ssl.SslSession
+import java.net.InetSocketAddress
+
+interface DtlsSessionLifecycleCallbacks {
+    enum class Reason {
+        SUCCEEDED, FAILED, CLOSED, EXPIRED
+    }
+    fun handshakeStarted(adr: InetSocketAddress, ctx: SslHandshakeContext) = Unit
+    fun handshakeFinished(adr: InetSocketAddress, ctx: SslHandshakeContext, reason: Reason, throwable: Throwable? = null) = Unit
+    fun sessionStarted(adr: InetSocketAddress, ctx: SslSession) = Unit
+    fun sessionFinished(adr: InetSocketAddress, ctx: SslSession, reason: Reason, throwable: Throwable? = null) = Unit
+}

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -239,7 +239,7 @@ class DtlsServerTest {
         assertEquals(0, cliChannel.read("aaa".toByteBuffer()))
         cliChannel.close()
 
-        verify(exactly = 100) {
+        verify(atMost = 100) {
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
         }
 

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -327,11 +327,11 @@ class DtlsServerTest {
             .connect(server.localAddress())
             .dropReceive { it > 0 } // drop everything after client hello with verify
 
-        // when
-        DtlsTransmitter.connect(server.localAddress(), timeoutClientConf, cli)
-
-        // then
         await.untilAsserted {
+            // when
+            DtlsTransmitter.connect(server.localAddress(), timeoutClientConf, cli)
+
+            // then
             assertEquals(1, server.numberOfSessions())
         }
 

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -342,7 +342,7 @@ class DtlsServerTest {
 
         cli.close()
 
-        verify (exactly = 1) {
+        verify(exactly = 1) {
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsServer.DtlsSessionLifecycleCallbacks.Reason.FAILED, and(ofType(SslException::class), not(ofType(HelloVerifyRequired::class))))
         }
     }

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -114,11 +114,11 @@ class DtlsServerTest {
         client.close()
 
         verifyOrder {
-            sslLifecycleCallbacks.handshakeStarted(clientAddress, any())
+            sslLifecycleCallbacks.handshakeStarted(clientAddress)
             sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
-            sslLifecycleCallbacks.handshakeStarted(clientAddress, any())
+            sslLifecycleCallbacks.handshakeStarted(clientAddress)
             sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
-            sslLifecycleCallbacks.sessionStarted(clientAddress, any())
+            sslLifecycleCallbacks.sessionStarted(clientAddress, any(), false)
         }
 
         // Check no more callbacks are called
@@ -166,14 +166,14 @@ class DtlsServerTest {
         }
         assertFalse(srvReceive.isDone)
         verifyOrder {
-            sslLifecycleCallbacks.handshakeStarted(any(), any())
+            sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
-            sslLifecycleCallbacks.handshakeStarted(any(), any())
+            sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
         }
 
         verify(exactly = 0) {
-            sslLifecycleCallbacks.sessionStarted(any(), any())
+            sslLifecycleCallbacks.sessionStarted(any(), any(), any())
         }
     }
 
@@ -196,10 +196,10 @@ class DtlsServerTest {
         client.close()
 
         verifyOrder {
-            sslLifecycleCallbacks.handshakeStarted(any(), any())
+            sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
-            sslLifecycleCallbacks.sessionStarted(any(), any())
-            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
+            sslLifecycleCallbacks.sessionStarted(any(), any(), any())
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
         }
     }
 
@@ -290,8 +290,8 @@ class DtlsServerTest {
         }
 
         verifyOrder {
-            sslLifecycleCallbacks.sessionStarted(any(), any())
-            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.CLOSED)
+            sslLifecycleCallbacks.sessionStarted(any(), any(), any())
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.CLOSED)
         }
     }
 
@@ -363,7 +363,7 @@ class DtlsServerTest {
         client.close()
 
         verify {
-            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
     }
 
@@ -396,14 +396,14 @@ class DtlsServerTest {
         client.close()
 
         verifyOrder() {
-            sslLifecycleCallbacks.handshakeStarted(any(), any())
+            sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
-            sslLifecycleCallbacks.handshakeStarted(any(), any())
+            sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
-            sslLifecycleCallbacks.sessionStarted(any(), any())
-            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
-            sslLifecycleCallbacks.sessionStarted(any(), match { it.reloaded })
-            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
+            sslLifecycleCallbacks.sessionStarted(any(), any(), false)
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
+            sslLifecycleCallbacks.sessionStarted(any(), any(), true)
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
 
         // Check no more callbacks are called

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -389,6 +389,10 @@ class DtlsServerTest {
         // then
         assertEquals("hi5:resp:dev-007", client.receiveString())
         assertEquals(1, server.numberOfSessions())
+
+        await.atMost(1.seconds).untilAsserted {
+            assertEquals(0, server.numberOfSessions())
+        }
         client.close()
 
         verifyOrder() {
@@ -399,6 +403,7 @@ class DtlsServerTest {
             sslLifecycleCallbacks.sessionStarted(any(), any())
             sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsServer.DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             sslLifecycleCallbacks.sessionStarted(any(), match { it.reloaded })
+            sslLifecycleCallbacks.sessionFinished(any(), any(), DtlsServer.DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
 
         // Check no more callbacks are called

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -93,7 +93,7 @@ class DtlsServerTest {
 
     @Test
     fun testSingleConnection() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks))
         val receive = server.receive(2.seconds)
 
         val client = DtlsTransmitter.connect(server, clientConfig).await()
@@ -153,7 +153,7 @@ class DtlsServerTest {
     @Test
     fun testFailedHandshake() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks))
         val srvReceive = server.receive(2.seconds)
         val clientFut = DtlsTransmitter.connect(server, SslConfig.client(psk.copy(pskSecret = byteArrayOf(-128))))
 
@@ -180,7 +180,7 @@ class DtlsServerTest {
     @Test
     fun testReceiveMalformedPacket() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("perse")
 
@@ -222,7 +222,7 @@ class DtlsServerTest {
     @Test
     fun testMalformedHandshakeMessage() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val cliChannel: DatagramChannel = DatagramChannel.open()
             .connect(InetSocketAddress(InetAddress.getLocalHost(), server.localPort()))
 
@@ -275,7 +275,7 @@ class DtlsServerTest {
 
     @Test
     fun `should send close notify`() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         await.untilAsserted {
             assertEquals(1, server.numberOfSessions())
@@ -297,7 +297,7 @@ class DtlsServerTest {
 
     @Test
     fun `should successfully handshake with retransmission`() {
-        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val cli = DatagramChannelAdapter
             .connect(localAddress(server.localPort()))
             .dropReceive { it == 1 } // drop ServerHello, the only message that server will retry
@@ -322,7 +322,7 @@ class DtlsServerTest {
 
     @Test
     fun `should remove handshake session when handshake timeout`() {
-        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val cli = DatagramChannelAdapter
             .connect(server.localAddress())
             .dropReceive { it > 0 } // drop everything after client hello with verify
@@ -350,7 +350,7 @@ class DtlsServerTest {
     @Test
     fun `should remove session after inactivity`() {
         // given
-        server = DtlsServer.create(conf, expireAfter = 10.millis, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, expireAfter = 10.millis, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("perse")
 
@@ -370,7 +370,7 @@ class DtlsServerTest {
     @Test
     fun `should reuse stored session after it is expired`() {
         // given
-        server = DtlsServer.create(conf, expireAfter = 100.millis, sessionStore = sessionStore, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        server = DtlsServer.create(conf, expireAfter = 100.millis, sessionStore = sessionStore, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
         // client connected
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("Authenticate:dev-007")

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -93,7 +93,7 @@ class DtlsServerTest {
 
     @Test
     fun testSingleConnection() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks))
+        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks)
         val receive = server.receive(2.seconds)
 
         val client = DtlsTransmitter.connect(server, clientConfig).await()
@@ -153,7 +153,7 @@ class DtlsServerTest {
     @Test
     fun testFailedHandshake() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks))
+        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks)
         val srvReceive = server.receive(2.seconds)
         val clientFut = DtlsTransmitter.connect(server, SslConfig.client(psk.copy(pskSecret = byteArrayOf(-128))))
 
@@ -180,7 +180,7 @@ class DtlsServerTest {
     @Test
     fun testReceiveMalformedPacket() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("perse")
 
@@ -222,7 +222,7 @@ class DtlsServerTest {
     @Test
     fun testMalformedHandshakeMessage() {
         // given
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val cliChannel: DatagramChannel = DatagramChannel.open()
             .connect(InetSocketAddress(InetAddress.getLocalHost(), server.localPort()))
 
@@ -275,7 +275,7 @@ class DtlsServerTest {
 
     @Test
     fun `should send close notify`() {
-        server = DtlsServer.create(conf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         await.untilAsserted {
             assertEquals(1, server.numberOfSessions())
@@ -297,7 +297,7 @@ class DtlsServerTest {
 
     @Test
     fun `should successfully handshake with retransmission`() {
-        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val cli = DatagramChannelAdapter
             .connect(localAddress(server.localPort()))
             .dropReceive { it == 1 } // drop ServerHello, the only message that server will retry
@@ -322,7 +322,7 @@ class DtlsServerTest {
 
     @Test
     fun `should remove handshake session when handshake timeout`() {
-        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(timeoutConf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val cli = DatagramChannelAdapter
             .connect(server.localAddress())
             .dropReceive { it > 0 } // drop everything after client hello with verify
@@ -350,7 +350,7 @@ class DtlsServerTest {
     @Test
     fun `should remove session after inactivity`() {
         // given
-        server = DtlsServer.create(conf, expireAfter = 10.millis, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, expireAfter = 10.millis, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("perse")
 
@@ -370,7 +370,7 @@ class DtlsServerTest {
     @Test
     fun `should reuse stored session after it is expired`() {
         // given
-        server = DtlsServer.create(conf, expireAfter = 100.millis, sessionStore = sessionStore, lifecycleCallbacks = listOf(sslLifecycleCallbacks)).listen(echoHandler)
+        server = DtlsServer.create(conf, expireAfter = 100.millis, sessionStore = sessionStore, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
         // client connected
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("Authenticate:dev-007")

--- a/kotlin-mbedtls/src/test/resources/logback.xml
+++ b/kotlin-mbedtls/src/test/resources/logback.xml
@@ -12,4 +12,5 @@
 
     <logger name="org.opencoap.ssl" level="debug"/>
     <logger name="org.opencoap.ssl.MbedtlsApi" level="info"/>
+    <logger name="io.mockk" level="info"/>
 </configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 include(":mbedtls-lib")
 include(":kotlin-mbedtls")
+include(":kotlin-mbedtls-metrics")
 rootProject.name = "kotlin-mbedtls"


### PR DESCRIPTION
Metrics example after one coap client request:
```
dtls_server_sessions_expired_total 0.0
dtls_server_sessions_started_total{suite="TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384",} 2.0
dtls_server_sessions_reloaded_total 0.0
dtls_server_sessions_closed_total 2.0
dtls_server_handshakes_expired_total 0.0
dtls_server_handshakes_initiated_total 4.0
dtls_server_handshakes_succeeded_seconds{quantile="0.5",} 0.006815744
dtls_server_handshakes_succeeded_seconds{quantile="0.95",} 0.006815744
dtls_server_handshakes_succeeded_seconds_count 2.0
dtls_server_handshakes_succeeded_seconds_sum 0.014
dtls_server_handshakes_succeeded_seconds_max 0.007
dtls_sessions 0.0
```