### PR TITLE
Run DTLS session lifecycle probes asynchronously

### DIFF
--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -54,10 +54,10 @@ class DtlsServerMetricsCallbacks(
         handshakesInitiated.increment()
     }
 
-    override fun handshakeFinished(adr: InetSocketAddress, hanshakeStartTimestamp: Long, reason: DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when {
+    override fun handshakeFinished(adr: InetSocketAddress, hanshakeStartTimestamp: Long, hanshakeFinishTimestamp: Long, reason: DtlsSessionLifecycleCallbacks.Reason, throwable: Throwable?) = when {
         throwable is HelloVerifyRequired -> {} // Skip HelloVerifyRequired handshake states
         reason == DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED ->
-            handshakesSucceeded.record(System.currentTimeMillis() - hanshakeStartTimestamp, TimeUnit.MILLISECONDS)
+            handshakesSucceeded.record(hanshakeFinishTimestamp - hanshakeStartTimestamp, TimeUnit.MILLISECONDS)
         reason == DtlsSessionLifecycleCallbacks.Reason.FAILED ->
             handshakesFailedBuilder.reasonTag(throwable).register(registry).increment()
         reason == DtlsSessionLifecycleCallbacks.Reason.EXPIRED ->

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -68,6 +68,7 @@ class SslHandshakeContext internal constructor(
 ) : SslContext {
     private val logger = LoggerFactory.getLogger(javaClass)
     val startTimestamp: Long = System.currentTimeMillis()
+    var finishTimestamp: Long = 0
     private var stepTimeout: Duration = Duration.ZERO
 
     fun step(send: (ByteBuffer) -> Unit): SslContext = step0(null, send)
@@ -86,7 +87,8 @@ class SslHandshakeContext internal constructor(
             MbedtlsApi.MBEDTLS_ERR_SSL_WANT_READ -> return this
             MbedtlsApi.MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED -> throw HelloVerifyRequired
             0 -> SslSession(conf, sslContext, cid).also {
-                logger.info("[{}] DTLS connected in {}ms {}", peerAdr, System.currentTimeMillis() - startTimestamp, it)
+                finishTimestamp = System.currentTimeMillis()
+                logger.info("[{}] DTLS connected in {}ms {}", peerAdr, finishTimestamp - startTimestamp, it)
             }
 
             else -> throw SslException.from(ret).also {

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -92,6 +92,7 @@ class SslHandshakeContext internal constructor(
             }
 
             else -> throw SslException.from(ret).also {
+                finishTimestamp = System.currentTimeMillis()
                 logger.debug("[{}] DTLS failed handshake: {}", peerAdr, it.message)
             }
         }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
@@ -23,7 +23,7 @@ interface DtlsSessionLifecycleCallbacks {
         SUCCEEDED, FAILED, CLOSED, EXPIRED
     }
     fun handshakeStarted(adr: InetSocketAddress) = Unit
-    fun handshakeFinished(adr: InetSocketAddress, hanshakeStartTimestamp: Long, reason: Reason, throwable: Throwable? = null) = Unit
+    fun handshakeFinished(adr: InetSocketAddress, hanshakeStartTimestamp: Long, hanshakeFinishTimestamp: Long, reason: Reason, throwable: Throwable? = null) = Unit
     fun sessionStarted(adr: InetSocketAddress, cipherSuite: String, reloaded: Boolean) = Unit
     fun sessionFinished(adr: InetSocketAddress, reason: Reason, throwable: Throwable? = null) = Unit
 }

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -114,9 +114,9 @@ class DtlsServerTransportTest {
 
         verifyOrder {
             sslLifecycleCallbacks.handshakeStarted(clientAddress)
-            sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
+            sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(clientAddress)
-            sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
+            sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(clientAddress, any(), false)
         }
 
@@ -166,9 +166,9 @@ class DtlsServerTransportTest {
         assertFalse(srvReceive.isDone)
         verifyOrder {
             sslLifecycleCallbacks.handshakeStarted(any())
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(any())
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
         }
 
         verify(exactly = 0) {
@@ -194,7 +194,7 @@ class DtlsServerTransportTest {
 
         verifyOrder {
             sslLifecycleCallbacks.handshakeStarted(any())
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), any())
         }
     }
@@ -236,11 +236,11 @@ class DtlsServerTransportTest {
         cliChannel.close()
 
         verify(atMost = 100) {
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(SslException::class))
         }
 
         verify(exactly = 0) {
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
         }
     }
 
@@ -307,12 +307,12 @@ class DtlsServerTransportTest {
 
         // No handshake failures other than HelloVerifyRequired
         verify(exactly = 0) {
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, not(ofType(HelloVerifyRequired::class)))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, not(ofType(HelloVerifyRequired::class)))
         }
 
         // One successful handshake must happen
         verify(exactly = 1) {
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
         }
     }
 
@@ -334,7 +334,7 @@ class DtlsServerTransportTest {
         cli.close()
 
         verify(exactly = 1) {
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, and(ofType(SslException::class), not(ofType(HelloVerifyRequired::class))))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, and(ofType(SslException::class), not(ofType(HelloVerifyRequired::class))))
         }
     }
 
@@ -388,9 +388,9 @@ class DtlsServerTransportTest {
 
         verifyOrder() {
             sslLifecycleCallbacks.handshakeStarted(any())
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(any())
-            sslLifecycleCallbacks.handshakeFinished(any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
+            sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), false)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), true)

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -20,7 +20,6 @@ import io.mockk.clearMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
-import io.mockk.verifyOrder
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -112,7 +111,7 @@ class DtlsServerTransportTest {
         val clientAddress = client.localAddress()
         client.close()
 
-        verifyOrder {
+        verify {
             sslLifecycleCallbacks.handshakeStarted(clientAddress)
             sslLifecycleCallbacks.handshakeFinished(clientAddress, any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(clientAddress)
@@ -164,7 +163,7 @@ class DtlsServerTransportTest {
             assertEquals(0, server.numberOfSessions())
         }
         assertFalse(srvReceive.isDone)
-        verifyOrder {
+        verify {
             sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(any())
@@ -192,7 +191,7 @@ class DtlsServerTransportTest {
 
         client.close()
 
-        verifyOrder {
+        verify {
             sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), any())
@@ -285,7 +284,7 @@ class DtlsServerTransportTest {
             assertEquals(0, server.numberOfSessions())
         }
 
-        verifyOrder {
+        verify {
             sslLifecycleCallbacks.sessionStarted(any(), any(), any())
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.CLOSED)
         }
@@ -386,7 +385,7 @@ class DtlsServerTransportTest {
         }
         client.close()
 
-        verifyOrder() {
+        verify() {
             sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
             sslLifecycleCallbacks.handshakeStarted(any())


### PR DESCRIPTION
It was found that disabling metrics increases the throughput during loadtesting (from ~200 to ~300 handshakes per second). Scheduling metrics counting as a postponed asynchronous task allows to approach the same throughput as was seen with metrics disabled.