### PR TITLE
Provide DTLS session start timestamp in the session context

### DIFF
--- a/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
+++ b/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
@@ -50,6 +50,7 @@ import org.opencoap.ssl.util.seconds
 import java.net.InetSocketAddress
 import java.nio.channels.ClosedChannelException
 import java.nio.charset.Charset
+import java.time.Instant
 import java.util.concurrent.ExecutionException
 import kotlin.random.Random
 
@@ -190,7 +191,7 @@ class NettyTest {
 
     @Test
     fun `server should load session from store`() {
-        sessionStore.write("059876266f7c5734fd352c5a3b7b3be2".decodeHex(), SessionWithContext(StoredSessionPair.srvSession, mapOf(), 123456789))
+        sessionStore.write("059876266f7c5734fd352c5a3b7b3be2".decodeHex(), SessionWithContext(StoredSessionPair.srvSession, mapOf(), Instant.ofEpochSecond(123456789)))
         val storeSessionMock: SessionWriter = mockk(relaxed = true)
         val client = NettyTransportAdapter.reload(clientConf.loadSession(byteArrayOf(), StoredSessionPair.cliSession, srvAddress), srvAddress, storeSessionMock).mapToString()
 

--- a/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
+++ b/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
@@ -190,7 +190,7 @@ class NettyTest {
 
     @Test
     fun `server should load session from store`() {
-        sessionStore.write("059876266f7c5734fd352c5a3b7b3be2".decodeHex(), SessionWithContext(StoredSessionPair.srvSession, mapOf()))
+        sessionStore.write("059876266f7c5734fd352c5a3b7b3be2".decodeHex(), SessionWithContext(StoredSessionPair.srvSession, mapOf(), 123456789))
         val storeSessionMock: SessionWriter = mockk(relaxed = true)
         val client = NettyTransportAdapter.reload(clientConf.loadSession(byteArrayOf(), StoredSessionPair.cliSession, srvAddress), srvAddress, storeSessionMock).mapToString()
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -26,7 +26,6 @@ import org.opencoap.ssl.SslSession
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CompletableFuture

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -211,7 +211,7 @@ class DtlsServer(
         private val ctx: SslSession,
         peerAddress: InetSocketAddress,
         var authenticationContext: AuthenticationContext = emptyMap(),
-        private val sessionStartTimestamp: Long = Instant.now().epochSecond
+        private val sessionStartTimestamp: Instant = Instant.now()
     ) : DtlsState(peerAddress) {
 
         val sessionContext: DtlsSessionContext

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServerTransport.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServerTransport.kt
@@ -114,6 +114,4 @@ class DtlsServerTransport private constructor(
         executor.supply {
             dtlsServer.putSessionAuthenticationContext(adr, key, value)
         }
-
-    fun getSessionCid(adr: InetSocketAddress) = executor.supply { dtlsServer.getSessionCid(adr) }
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionContext.kt
@@ -16,13 +16,15 @@
 
 package org.opencoap.ssl.transport
 
+import java.time.Instant
+
 typealias AuthenticationContext = Map<String, String>
 
 data class DtlsSessionContext @JvmOverloads constructor(
     val authenticationContext: AuthenticationContext = emptyMap(),
     val peerCertificateSubject: String? = null,
     val cid: ByteArray? = null,
-    val sessionStartTimestamp: Long? = null
+    val sessionStartTimestamp: Instant? = null
 ) {
     companion object {
         @JvmField

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionContext.kt
@@ -21,7 +21,8 @@ typealias AuthenticationContext = Map<String, String>
 data class DtlsSessionContext @JvmOverloads constructor(
     val authenticationContext: AuthenticationContext = emptyMap(),
     val peerCertificateSubject: String? = null,
-    val cid: ByteArray? = null
+    val cid: ByteArray? = null,
+    val sessionStartTimestamp: Long? = null
 ) {
     companion object {
         @JvmField
@@ -40,6 +41,7 @@ data class DtlsSessionContext @JvmOverloads constructor(
             if (other.cid == null) return false
             if (!cid.contentEquals(other.cid)) return false
         } else if (other.cid != null) return false
+        if (sessionStartTimestamp != other.sessionStartTimestamp) return false
 
         return true
     }
@@ -48,6 +50,7 @@ data class DtlsSessionContext @JvmOverloads constructor(
         var result = authenticationContext.hashCode()
         result = 31 * result + (peerCertificateSubject?.hashCode() ?: 0)
         result = 31 * result + (cid?.contentHashCode() ?: 0)
+        result = 31 * result + (sessionStartTimestamp?.hashCode() ?: 0)
         return result
     }
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/SessionStore.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/SessionStore.kt
@@ -29,7 +29,8 @@ interface SessionStore {
 
 data class SessionWithContext(
     val sessionBlob: ByteArray,
-    val authenticationContext: AuthenticationContext
+    val authenticationContext: AuthenticationContext,
+    val sessionStartTimestamp: Long
 )
 
 fun interface SessionWriter {

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/SessionStore.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/SessionStore.kt
@@ -16,6 +16,7 @@
 
 package org.opencoap.ssl.transport
 
+import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -30,7 +31,7 @@ interface SessionStore {
 data class SessionWithContext(
     val sessionBlob: ByteArray,
     val authenticationContext: AuthenticationContext,
-    val sessionStartTimestamp: Long
+    val sessionStartTimestamp: Instant
 )
 
 fun interface SessionWriter {

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -37,7 +37,6 @@ import org.opencoap.ssl.util.localAddress
 import org.opencoap.ssl.util.millis
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.time.Clock
 import java.time.Instant
 import java.util.LinkedList
 import java.util.concurrent.CompletableFuture

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -80,12 +80,12 @@ class DtlsServerTest {
         assertTrue(dtlsServer.handleReceived(localAddress(2_5684), dtlsPacket) is ReceiveResult.CidSessionMissing)
 
         // when
-        dtlsServer.loadSession(SessionWithContext(StoredSessionPair.srvSession, mapOf(), 123456789), localAddress(2_5684), "f935adc57425e1b214f8640d56e0c733".decodeHex())
+        dtlsServer.loadSession(SessionWithContext(StoredSessionPair.srvSession, mapOf(), Instant.ofEpochSecond(123456789)), localAddress(2_5684), "f935adc57425e1b214f8640d56e0c733".decodeHex())
 
         // then
         val dtlsPacketIn = (dtlsServer.handleReceived(localAddress(2_5684), dtlsPacket) as ReceiveResult.Decrypted).packet
         assertEquals("hello", dtlsPacketIn.buffer.decodeToString())
-        assertEquals(123456789, dtlsPacketIn.sessionContext.sessionStartTimestamp)
+        assertEquals(Instant.ofEpochSecond(123456789), dtlsPacketIn.sessionContext.sessionStartTimestamp)
         val dtlsPacketOut = dtlsServer.encrypt("hello2".toByteBuffer(), localAddress(2_5684))!!.order(ByteOrder.BIG_ENDIAN)
         assertEquals("hello2", clientSession.decrypt(dtlsPacketOut, noSend).decodeToString())
 
@@ -111,7 +111,7 @@ class DtlsServerTest {
         val dtlsPacket = clientSession.encrypt("terve".toByteBuffer()).order(ByteOrder.BIG_ENDIAN)
         val dtlsPacketIn = (dtlsServer.handleReceived(localAddress(2_5684), dtlsPacket) as ReceiveResult.Decrypted).packet
         assertEquals("terve", dtlsPacketIn.buffer.decodeToString())
-        assertTrue(Instant.now().epochSecond >= dtlsPacketIn.sessionContext.sessionStartTimestamp!!)
+        assertTrue(Instant.now().isAfter(dtlsPacketIn.sessionContext.sessionStartTimestamp!!))
 
         assertEquals(1, dtlsServer.numberOfSessions)
         assertTrue(serverOutboundQueue.isEmpty())

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -24,8 +24,6 @@ import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.opencoap.ssl.CertificateAuth

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -24,6 +24,7 @@ import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -439,12 +440,15 @@ class DtlsServerTransportTest {
     }
 
     @Test
-    fun `should not return cid`() {
-        server = DtlsServerTransport.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+    fun `should put client's cid in the session context`() {
+        server = DtlsServerTransport.create(conf)
+        val serverReceived = server.receive(1.seconds)
         val client = DtlsTransmitter.connect(server, clientConfig).await()
         client.send("hello!")
-        val cid = server.getSessionCid(localAddress(1234)).await()
-        assertNull(cid)
+
+        assertTrue(client.peerCid.contentEquals(serverReceived.await().sessionContext.cid))
+
+        client.close()
     }
 
     @Test


### PR DESCRIPTION
Also getting rid of the `getSessionCid()` here as I realized it should be retrieved by the library users the same way as authentication context is accessed.