### PR TITLE
Automate post-actions after mbedtls update

### DIFF
--- a/.github/workflows/update-mbedtls.yml
+++ b/.github/workflows/update-mbedtls.yml
@@ -51,6 +51,7 @@ jobs:
           NEW_MBEDTLS_VERSION: ${{ needs.get-latest-mbedtls-version.outputs.mbedtlsVersion }}
         run: |
           sed -i 's/^\(DEFAULT_MBEDTLS_VERSION=\).\+$/\1'${NEW_MBEDTLS_VERSION}'/' compileMbedtls.sh
+          sed -i 's/^\(mbedtlsVersion=\).\+$/\1'${NEW_MBEDTLS_VERSION}'/' kotlin-mbedtls/src/main/resources/mbedtls.properties
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
+++ b/kotlin-mbedtls-netty/src/test/kotlin/org/opencoap/ssl/netty/NettyTest.kt
@@ -45,7 +45,6 @@ import org.opencoap.ssl.transport.Transport
 import org.opencoap.ssl.util.Certs
 import org.opencoap.ssl.util.StoredSessionPair
 import org.opencoap.ssl.util.await
-import org.opencoap.ssl.util.decodeHex
 import org.opencoap.ssl.util.localAddress
 import org.opencoap.ssl.util.seconds
 import java.net.InetSocketAddress
@@ -199,7 +198,7 @@ class NettyTest {
 
     @Test
     fun `server should load session from store`() {
-        sessionStore.write("059876266f7c5734fd352c5a3b7b3be2".decodeHex(), SessionWithContext(StoredSessionPair.srvSession, mapOf(), Instant.ofEpochSecond(123456789)))
+        sessionStore.write(StoredSessionPair.cid, SessionWithContext(StoredSessionPair.srvSession, mapOf(), Instant.ofEpochSecond(123456789)))
         val storeSessionMock: SessionWriter = mockk(relaxed = true)
         val client = NettyTransportAdapter.reload(clientConf.loadSession(byteArrayOf(), StoredSessionPair.cliSession, srvAddress), srvAddress, storeSessionMock).mapToString()
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -27,12 +27,18 @@ import com.sun.jna.Platform
 import com.sun.jna.Pointer
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
+import java.util.Properties
 
 /*
 Defines mbedtls native functions that can be used from jvm.
  */
 internal object MbedtlsApi {
-    private val libraryName = if (Platform.isWindows()) "libmbedtls-3.4.0" else "mbedtls-3.4.0"
+    private val libraryName = javaClass.classLoader.getResourceAsStream("mbedtls.properties").use { resource ->
+        Properties().apply { load(resource) }.let { props ->
+            val mbedtlsVersion = props.getProperty("mbedtlsVersion")
+            if (Platform.isWindows()) "libmbedtls-$mbedtlsVersion" else "mbedtls-$mbedtlsVersion"
+        }
+    }
     private val LIB_MBEDTLS = NativeLibrary.getInstance(libraryName)
 
     init {

--- a/kotlin-mbedtls/src/main/resources/mbedtls.properties
+++ b/kotlin-mbedtls/src/main/resources/mbedtls.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mbedtlsVersion=3.4.1


### PR DESCRIPTION
The hardcoded serialized mbedtls session contains library version. To keep up with the current mbedtls version I decided to generate that mbedtls session fixture during the test.