### PR TITLE
fix: properly parse session ID in ClientHello header

### DIFF
--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -275,6 +275,26 @@ class DtlsServerTest {
         clientSession.close()
     }
 
+    @Test
+    fun `should properly seek through the buffer`() {
+        var buf = ByteBuffer.wrap("FFFF01FF0001FF".decodeHex())
+        buf.position(1)
+        buf.seek(1)
+        buf.seek(-2)
+        buf.seek(2)
+        assertEquals(2, buf.position())
+        buf.readByteAndSeek()
+        assertEquals(4, buf.position())
+        buf.readShortAndSeek()
+        assertEquals(7, buf.position())
+
+        buf = ByteBuffer.wrap("FF".decodeHex() + ByteArray(255) + "FFFF".decodeHex() + ByteArray(65535))
+        buf.readByteAndSeek()
+        assertEquals(256, buf.position())
+        buf.readShortAndSeek()
+        assertEquals(65793, buf.position())
+    }
+
     private fun clientHandshake(): SslSession {
         val send: (ByteBuffer) -> Unit = { dtlsServer.handleReceived(localAddress(2_5684), it) }
         val cliHandshake = clientConf.newContext(localAddress(5684))


### PR DESCRIPTION
Several issues with new handshake datagram validation were found:
1. Due to sign errors we were seeking out of the buffer for some correct datagrams.
2. Sequence number actually increments with every attempt of a ClientHello (also on HelloVerifyRequired).
3. Session ID is not always empty on ClientHello.