### PR TITLE
fix: update workflow to create MbedtlsSizeOf.kt file

### DIFF
--- a/.github/workflows/compile-mbedtls.yml
+++ b/.github/workflows/compile-mbedtls.yml
@@ -29,6 +29,12 @@ jobs:
           name: linux-x86-64
           path: mbedtls-lib/bin/linux-x86-64/*
           if-no-files-found: error
+      - name: Archive mbledtlsSizeOf.kt
+        uses: actions/upload-artifact@v4
+        with:
+          name: MbedtlsSizeOf.kt
+          path: kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsSizeOf.kt
+          if-no-files-found: error
 
   compile-macos:
     name: "compile: macos"

--- a/.github/workflows/update-mbedtls.yml
+++ b/.github/workflows/update-mbedtls.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: MbedtlsSizeOf.kt
-          path: kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsSizeOf.kt
+          path: kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/
       - name: Bump default compile version
         env:
           NEW_MBEDTLS_VERSION: ${{ needs.get-mbedtls-version.outputs.latestMbedtlsVersion }}

--- a/.github/workflows/update-mbedtls.yml
+++ b/.github/workflows/update-mbedtls.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           name: win32-x86-64
           path: mbedtls-lib/bin/win32-x86-64/
+      - uses: actions/download-artifact@v4
+        with:
+          name: MbedtlsSizeOf.kt
+          path: kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsSizeOf.kt
       - name: Bump default compile version
         env:
           NEW_MBEDTLS_VERSION: ${{ needs.get-mbedtls-version.outputs.latestMbedtlsVersion }}


### PR DESCRIPTION
**Problem:**
Workflow for updating mbedtls is missing `MbedtlsSizeOf.kt`

**Why?**
The `compileMbedtlst.sh` script to create the file is never executed in the instance where the PR is created, since the downloaded artifacts only contain the binaries.

**Solution:**
~~Run the compile script to create the `MbedtlsSizeOf.kt` file and then remove the binaries~~
Create a new artifact inside `compileMbedtlst.sh` and pass the file from there