### PR TITLE
Add metric for counting number of sessions stored

### DIFF
--- a/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
+++ b/kotlin-mbedtls-metrics/src/main/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacks.kt
@@ -48,6 +48,7 @@ class DtlsServerMetricsCallbacks(
     private val sessionsClosed = registry.counter("$metricsPrefix.sessions.closed")
     private val sessionsFailedBuilder = Counter.builder("$metricsPrefix.sessions.failed")
     private val sessionsExpired = registry.counter("$metricsPrefix.sessions.expired")
+    private val sessionsStored = registry.counter("$metricsPrefix.sessions.stored")
     private val sessionsReloaded = registry.counter("$metricsPrefix.sessions.reloaded")
     private val messagesDropped = registry.counter("$metricsPrefix.messages.dropped")
 
@@ -79,6 +80,8 @@ class DtlsServerMetricsCallbacks(
             sessionsClosed.increment()
         DtlsSessionLifecycleCallbacks.Reason.EXPIRED ->
             sessionsExpired.increment()
+        DtlsSessionLifecycleCallbacks.Reason.STORED ->
+            sessionsStored.increment()
         else -> {}
     }
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsSessionLifecycleCallbacks.kt
@@ -24,7 +24,8 @@ interface DtlsSessionLifecycleCallbacks {
         SUCCEEDED,
         FAILED,
         CLOSED,
-        EXPIRED
+        EXPIRED,
+        STORED
     }
 
     fun handshakeStarted(adr: InetSocketAddress) = Unit

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -353,6 +353,7 @@ class DtlsServerTransportTest {
         client.close()
 
         verify {
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
     }
@@ -391,8 +392,10 @@ class DtlsServerTransportTest {
             sslLifecycleCallbacks.handshakeStarted(any())
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), false)
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), true)
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
 


### PR DESCRIPTION
The idea is to count session expirations and session storings separately. Expired sessions are also counted as stored. Sessions enforced to be stored (e.g. via a user request) will be counted only as stored.