### PR TITLE
feat: replace JNA with Java FFM API (Panama), require Java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21', '25' ]
-        platform: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
-        exclude:
-          - platform: ${{ github.repository == 'open-coap/kotlin-mbedtls' || 'macos-latest' }}
-
+        java: [ '25' ]
+        # linux-x64, mac arm64, mac intel-x64, windows-x64
+        platform: [ 'ubuntu-latest', 'macos-latest', 'macos-13', 'windows-latest' ]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -36,10 +34,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'corretto'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 17
-          distribution: 'adopt'
+          java-version: 25
+          distribution: 'corretto'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Build

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,17 @@ Kotlin + mbedtls integration
 
 Integration with mbedtls library to provide DTLS protocol into jvm ecosystem.
 
+## Requirements
+
+- **Java 25 or newer is required.** Native access to mbedtls uses the JDK [Foreign Function & Memory API](https://openjdk.org/jeps/454)
+  (Panama) instead of JNA. There is no longer a `net.java.dev.jna` dependency, and no native libraries are extracted via
+  JNA machinery.
+- FFM downcalls/upcalls are "restricted" operations. The library works out of the box, but to silence the JDK runtime
+  warning, launch your application with `--enable-native-access=ALL-UNNAMED` (or add `Enable-Native-Access: ALL-UNNAMED`
+  to your executable jar manifest).
+- **Pre-Java-25 users:** stay on the last JNA-based release (`1.x` line published before this change); it remains usable
+  on Java 8+ but will not receive the FFM-based updates.
+
 ## Features:
 
 - Precompiled mbedtls binaries for

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,24 +44,35 @@ allprojects {
     project.version = rootProject.version
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(25))
+        }
     }
 
     kotlin {
+        jvmToolchain(25)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
+            jvmTarget.set(JvmTarget.JVM_25)
             allWarningsAsErrors = true
             extraWarnings = true
         }
     }
 
     tasks {
+        // detekt 2.0.0-alpha.1 bundles a Kotlin compiler that caps jvm-target at 24; analysis target only.
         withType<Detekt>().configureEach {
-            jvmTarget = "1.8"
+            jvmTarget = "24"
         }
         withType<DetektCreateBaselineTask>().configureEach {
-            jvmTarget = "1.8"
+            jvmTarget = "24"
+        }
+
+        // FFM downcalls/upcalls invoke restricted native methods; allow them without warnings on Java 25+.
+        withType<Test>().configureEach {
+            jvmArgs("--enable-native-access=ALL-UNNAMED")
+        }
+        withType<JavaExec>().configureEach {
+            jvmArgs("--enable-native-access=ALL-UNNAMED")
         }
 
         withType<DependencyUpdatesTask> {

--- a/kotlin-mbedtls-metrics/build.gradle.kts
+++ b/kotlin-mbedtls-metrics/build.gradle.kts
@@ -14,9 +14,4 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-    // On Windows, native libraries must be found via PATH or explicitly set, as dynamic linking is used to load them.
-    if (System.getProperty("os.name").lowercase().contains("win")) {
-        val osArch = "win32-x86-64"
-        systemProperty("jna.library.path", file("../mbedtls-lib/bin/$osArch").absolutePath)
-    }
 }

--- a/kotlin-mbedtls-netty/build.gradle.kts
+++ b/kotlin-mbedtls-netty/build.gradle.kts
@@ -22,9 +22,8 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-    // On Windows, native libraries must be found via PATH or explicitly set, as dynamic linking is used to load them.
-    if (System.getProperty("os.name").lowercase().contains("win")) {
-        val osArch = "win32-x86-64"
-        systemProperty("jna.library.path", file("../mbedtls-lib/bin/$osArch").absolutePath)
-    }
+}
+
+jmh {
+    jvmArgsAppend.add("--enable-native-access=ALL-UNNAMED")
 }

--- a/kotlin-mbedtls/build.gradle.kts
+++ b/kotlin-mbedtls/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     api(project(":mbedtls-lib"))
 
     api("org.slf4j:slf4j-api:2.0.17")
-    api("net.java.dev.jna:jna:5.18.1")
 
     // TESTS
     testFixturesApi("org.bouncycastle:bcpkix-jdk15on:1.70")
@@ -23,15 +22,11 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-    // On Windows, native libraries must be found via PATH or explicitly set, as dynamic linking is used to load them.
-    if (System.getProperty("os.name").lowercase().contains("win")) {
-        val osArch = "win32-x86-64"
-        systemProperty("jna.library.path", file("../mbedtls-lib/bin/$osArch").absolutePath)
-    }
 }
 
 jmh {
     failOnError.set(true)
+    jvmArgsAppend.add("--enable-native-access=ALL-UNNAMED")
     // Read -PjmhInclude(comma separated)
     val includeProp = findProperty("jmhIncludes")?.toString()
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,69 +14,229 @@
  * limitations under the License.
  */
 
-@file:Suppress("FunctionNaming")
+@file:Suppress("FunctionNaming", "TooManyFunctions")
 
 package org.opencoap.ssl
 
-import com.sun.jna.Callback
-import com.sun.jna.Function
-import com.sun.jna.Memory
-import com.sun.jna.Native
-import com.sun.jna.NativeLibrary
-import com.sun.jna.Pointer
 import org.slf4j.LoggerFactory
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
 import java.nio.ByteBuffer
 
 /*
-Defines mbedtls native functions that can be used from jvm.
+Defines mbedtls native functions that can be used from the jvm via the Foreign Function & Memory API.
+
+Each native function is exposed as a cached MethodHandle downcall with an explicit FunctionDescriptor and is
+dispatched with invokeExact. ABI widths mirror the previous JNA signatures: native `size_t` parameters are
+declared as 32-bit `int` (JAVA_INT) to minimize change. The wrappers keep Kotlin-friendly signatures and
+convert ByteArray/String/ByteBuffer arguments into off-heap MemorySegments on a per-call confined Arena.
  */
 internal object MbedtlsApi {
 
-    private var LIB_TFPSACRYPTO: NativeLibrary = NativeLibrary.getInstance("tfpsacrypto")
-    private var LIB_MBEDX509: NativeLibrary = NativeLibrary.getInstance("mbedx509")
-    private var LIB_MBEDTLS: NativeLibrary = NativeLibrary.getInstance("mbedtls")
+    private val linker: Linker = Linker.nativeLinker()
+    private val lookup: SymbolLookup = MbedtlsNativeLoader.lookup
 
-    init {
-        Native.register(LIB_MBEDTLS)
-        Native.register(X509::class.java, LIB_MBEDX509)
-        Native.register(Crypto::class.java, LIB_TFPSACRYPTO)
+    private val ADDRESS = ValueLayout.ADDRESS
+    private val INT = ValueLayout.JAVA_INT
+    private val BYTE = ValueLayout.JAVA_BYTE
 
-        configureLogThreshold()
+    private fun handle(name: String, descriptor: FunctionDescriptor): MethodHandle {
+        val symbol = lookup.find(name).orElseThrow { UnsatisfiedLinkError("Native symbol not found: $name") }
+        return linker.downcallHandle(symbol, descriptor)
     }
 
-    // mbedtls/ssl.h
-    external fun mbedtls_ssl_conf_authmode(mbedtlsSslConfig: Pointer, authmode: Int)
-    external fun mbedtls_ssl_conf_ciphersuites(sslConfig: Pointer, cipherSuiteIds: Memory)
-    external fun mbedtls_ssl_conf_dbg(mbedtlsSslConfig: Pointer, callback: Callback, pDbg: Pointer?)
-    external fun mbedtls_ssl_conf_dtls_cookies(mbedtlsSslConfig: Pointer, fCookieWrite: Function?, fCookieCheck: Function?, pCookie: Pointer?)
-    external fun mbedtls_ssl_conf_handshake_timeout(sslConfig: Pointer, min: Int, max: Int)
-    external fun mbedtls_ssl_conf_psk(conf: Pointer, psk: ByteArray, pskLen: Int, pskIdentity: ByteArray, pskIdentityLen: Int): Int
-    external fun mbedtls_ssl_config_defaults(mbedtlsSslConfig: Pointer, endpoint: Int, transport: Int, preset: Int): Int
-    external fun mbedtls_ssl_config_free(sslContext: Pointer)
-    external fun mbedtls_ssl_config_init(sslContext: Pointer)
-    external fun mbedtls_ssl_close_notify(sslContext: Pointer): Int
-    external fun mbedtls_ssl_free(sslContext: Pointer)
-    external fun mbedtls_ssl_get_ciphersuite(sslContext: Pointer): String
-    external fun mbedtls_ssl_get_ciphersuite_id(name: String): Int
-    external fun mbedtls_ssl_handshake(sslContext: Pointer): Int
-    external fun mbedtls_ssl_init(sslContext: Pointer)
-    external fun mbedtls_ssl_read(sslContext: Pointer, buf: ByteBuffer, len: Int): Int
-    external fun mbedtls_ssl_set_client_transport_id(sslContext: Pointer, info: String, ilen: Int): Int
-    external fun mbedtls_ssl_set_bio(sslContext: Pointer, pBaseIO: Pointer?, fSend: Callback, fRecv: Callback?, fRecvTimeout: Callback?)
-    external fun mbedtls_ssl_set_timer_cb(ssl: Pointer, timer: Pointer?, timingSetDelay: Callback, timingGetDelay: Callback)
-    external fun mbedtls_ssl_setup(sslContext: Pointer, mbedtlsSslConfig: Pointer): Int
-    external fun mbedtls_ssl_write(sslContext: Pointer, buf: ByteBuffer, len: Int): Int
-    external fun mbedtls_ssl_conf_cid(mbedtlsSslConfig: Pointer, len: Int, ignoreOtherCids: Int): Int
-    external fun mbedtls_ssl_set_cid(sslContext: Pointer, enable: Int, ownCid: ByteArray, ownCidLen: Int): Int
-    external fun mbedtls_ssl_get_peer_cid(sslContext: Pointer, enabled: Pointer, peerCid: Pointer, peerCidLen: Pointer): Int
-    external fun mbedtls_ssl_context_save(sslContext: Pointer, buf: ByteArray, bufLen: Int, outputLen: ByteArray): Int
-    external fun mbedtls_ssl_context_load(sslContext: Pointer, buf: ByteArray, len: Int): Int
-    external fun mbedtls_ssl_check_record(sslContext: Pointer, buf: Memory, bufLen: Int): Int
-    external fun mbedtls_ssl_conf_ca_chain(sslConfig: Pointer, caChain: Pointer, caCrl: Pointer?)
-    external fun mbedtls_ssl_conf_own_cert(sslConfig: Pointer, ownCert: Memory, pkKey: Pointer): Int
-    external fun mbedtls_ssl_set_mtu(sslContext: Pointer, mtu: Int)
-    external fun mbedtls_ssl_get_peer_cert(sslContext: Pointer): Pointer?
-    external fun mbedtls_ssl_set_hostname(sslContext: Pointer, hostname: String?): Int
+    fun symbol(name: String): MemorySegment = lookup.find(name).orElseThrow { UnsatisfiedLinkError("Native symbol not found: $name") }
+
+    private fun Arena.copyOf(bytes: ByteArray): MemorySegment {
+        val segment = allocate(if (bytes.isEmpty()) 1L else bytes.size.toLong())
+        if (bytes.isNotEmpty()) MemorySegment.copy(bytes, 0, segment, BYTE, 0L, bytes.size)
+        return segment
+    }
+
+    // ----- mbedtls/ssl.h -----
+
+    private val H_conf_authmode = handle("mbedtls_ssl_conf_authmode", FunctionDescriptor.ofVoid(ADDRESS, INT))
+    fun mbedtls_ssl_conf_authmode(mbedtlsSslConfig: MemorySegment, authmode: Int) {
+        H_conf_authmode.invokeExact(mbedtlsSslConfig, authmode)
+    }
+
+    private val H_conf_ciphersuites = handle("mbedtls_ssl_conf_ciphersuites", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS))
+    fun mbedtls_ssl_conf_ciphersuites(sslConfig: MemorySegment, cipherSuiteIds: MemorySegment) {
+        H_conf_ciphersuites.invokeExact(sslConfig, cipherSuiteIds)
+    }
+
+    private val H_conf_dbg = handle("mbedtls_ssl_conf_dbg", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_conf_dbg(mbedtlsSslConfig: MemorySegment, callback: MemorySegment, pDbg: MemorySegment) {
+        H_conf_dbg.invokeExact(mbedtlsSslConfig, callback, pDbg)
+    }
+
+    private val H_conf_dtls_cookies = handle("mbedtls_ssl_conf_dtls_cookies", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_conf_dtls_cookies(mbedtlsSslConfig: MemorySegment, fCookieWrite: MemorySegment, fCookieCheck: MemorySegment, pCookie: MemorySegment) {
+        H_conf_dtls_cookies.invokeExact(mbedtlsSslConfig, fCookieWrite, fCookieCheck, pCookie)
+    }
+
+    private val H_conf_handshake_timeout = handle("mbedtls_ssl_conf_handshake_timeout", FunctionDescriptor.ofVoid(ADDRESS, INT, INT))
+    fun mbedtls_ssl_conf_handshake_timeout(sslConfig: MemorySegment, min: Int, max: Int) {
+        H_conf_handshake_timeout.invokeExact(sslConfig, min, max)
+    }
+
+    private val H_conf_psk = handle("mbedtls_ssl_conf_psk", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT, ADDRESS, INT))
+    fun mbedtls_ssl_conf_psk(conf: MemorySegment, psk: ByteArray, pskLen: Int, pskIdentity: ByteArray, pskIdentityLen: Int): Int = Arena.ofConfined().use { arena ->
+        mbedtls_ssl_conf_psk_native(conf, arena.copyOf(psk), pskLen, arena.copyOf(pskIdentity), pskIdentityLen)
+    }
+
+    private fun mbedtls_ssl_conf_psk_native(conf: MemorySegment, psk: MemorySegment, pskLen: Int, pskIdentity: MemorySegment, pskIdentityLen: Int): Int = H_conf_psk.invokeExact(conf, psk, pskLen, pskIdentity, pskIdentityLen) as Int
+
+    private val H_config_defaults = handle("mbedtls_ssl_config_defaults", FunctionDescriptor.of(INT, ADDRESS, INT, INT, INT))
+    fun mbedtls_ssl_config_defaults(mbedtlsSslConfig: MemorySegment, endpoint: Int, transport: Int, preset: Int): Int = H_config_defaults.invokeExact(mbedtlsSslConfig, endpoint, transport, preset) as Int
+
+    private val H_config_free = handle("mbedtls_ssl_config_free", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_config_free(sslConfig: MemorySegment) {
+        H_config_free.invokeExact(sslConfig)
+    }
+
+    private val H_config_init = handle("mbedtls_ssl_config_init", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_config_init(sslConfig: MemorySegment) {
+        H_config_init.invokeExact(sslConfig)
+    }
+
+    private val H_close_notify = handle("mbedtls_ssl_close_notify", FunctionDescriptor.of(INT, ADDRESS))
+    fun mbedtls_ssl_close_notify(sslContext: MemorySegment): Int = H_close_notify.invokeExact(sslContext) as Int
+
+    private val H_ssl_free = handle("mbedtls_ssl_free", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_free(sslContext: MemorySegment) {
+        H_ssl_free.invokeExact(sslContext)
+    }
+
+    private val H_get_ciphersuite = handle("mbedtls_ssl_get_ciphersuite", FunctionDescriptor.of(ADDRESS, ADDRESS))
+    fun mbedtls_ssl_get_ciphersuite(sslContext: MemorySegment): String = (H_get_ciphersuite.invokeExact(sslContext) as MemorySegment).readCString()
+
+    private val H_get_ciphersuite_id = handle("mbedtls_ssl_get_ciphersuite_id", FunctionDescriptor.of(INT, ADDRESS))
+    fun mbedtls_ssl_get_ciphersuite_id(name: String): Int = Arena.ofConfined().use { arena -> mbedtls_ssl_get_ciphersuite_id_native(arena.allocateFrom(name)) }
+
+    private fun mbedtls_ssl_get_ciphersuite_id_native(name: MemorySegment): Int = H_get_ciphersuite_id.invokeExact(name) as Int
+
+    private val H_handshake = handle("mbedtls_ssl_handshake", FunctionDescriptor.of(INT, ADDRESS))
+    fun mbedtls_ssl_handshake(sslContext: MemorySegment): Int = H_handshake.invokeExact(sslContext) as Int
+
+    private val H_ssl_init = handle("mbedtls_ssl_init", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_init(sslContext: MemorySegment) {
+        H_ssl_init.invokeExact(sslContext)
+    }
+
+    private val H_ssl_read = handle("mbedtls_ssl_read", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+    fun mbedtls_ssl_read(sslContext: MemorySegment, buf: ByteBuffer, len: Int): Int {
+        if (buf.isDirect) {
+            return mbedtls_ssl_read_native(sslContext, MemorySegment.ofBuffer(buf), len)
+        }
+        return Arena.ofConfined().use { arena ->
+            val segment = arena.allocate(len.coerceAtLeast(1).toLong())
+            val ret = mbedtls_ssl_read_native(sslContext, segment, len)
+            if (ret > 0) {
+                val pos = buf.position()
+                MemorySegment.copy(segment, BYTE, 0L, buf.array(), buf.arrayOffset() + pos, ret)
+            }
+            ret
+        }
+    }
+
+    private fun mbedtls_ssl_read_native(sslContext: MemorySegment, buf: MemorySegment, len: Int): Int = H_ssl_read.invokeExact(sslContext, buf, len) as Int
+
+    private val H_set_client_transport_id = handle("mbedtls_ssl_set_client_transport_id", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+    fun mbedtls_ssl_set_client_transport_id(sslContext: MemorySegment, info: String, ilen: Int): Int = Arena.ofConfined().use { arena -> mbedtls_ssl_set_client_transport_id_native(sslContext, arena.allocateFrom(info), ilen) }
+
+    private fun mbedtls_ssl_set_client_transport_id_native(sslContext: MemorySegment, info: MemorySegment, ilen: Int): Int = H_set_client_transport_id.invokeExact(sslContext, info, ilen) as Int
+
+    private val H_set_bio = handle("mbedtls_ssl_set_bio", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_set_bio(sslContext: MemorySegment, pBaseIO: MemorySegment, fSend: MemorySegment, fRecv: MemorySegment, fRecvTimeout: MemorySegment) {
+        H_set_bio.invokeExact(sslContext, pBaseIO, fSend, fRecv, fRecvTimeout)
+    }
+
+    private val H_set_timer_cb = handle("mbedtls_ssl_set_timer_cb", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_set_timer_cb(ssl: MemorySegment, timer: MemorySegment, timingSetDelay: MemorySegment, timingGetDelay: MemorySegment) {
+        H_set_timer_cb.invokeExact(ssl, timer, timingSetDelay, timingGetDelay)
+    }
+
+    private val H_ssl_setup = handle("mbedtls_ssl_setup", FunctionDescriptor.of(INT, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_setup(sslContext: MemorySegment, mbedtlsSslConfig: MemorySegment): Int = H_ssl_setup.invokeExact(sslContext, mbedtlsSslConfig) as Int
+
+    private val H_ssl_write = handle("mbedtls_ssl_write", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+    fun mbedtls_ssl_write(sslContext: MemorySegment, buf: ByteBuffer, len: Int): Int {
+        if (buf.isDirect) {
+            return mbedtls_ssl_write_native(sslContext, MemorySegment.ofBuffer(buf), len)
+        }
+        return Arena.ofConfined().use { arena ->
+            val segment = arena.allocate(len.coerceAtLeast(1).toLong())
+            MemorySegment.copy(buf.array(), buf.arrayOffset() + buf.position(), segment, BYTE, 0L, len)
+            mbedtls_ssl_write_native(sslContext, segment, len)
+        }
+    }
+
+    private fun mbedtls_ssl_write_native(sslContext: MemorySegment, buf: MemorySegment, len: Int): Int = H_ssl_write.invokeExact(sslContext, buf, len) as Int
+
+    private val H_conf_cid = handle("mbedtls_ssl_conf_cid", FunctionDescriptor.of(INT, ADDRESS, INT, INT))
+    fun mbedtls_ssl_conf_cid(mbedtlsSslConfig: MemorySegment, len: Int, ignoreOtherCids: Int): Int = H_conf_cid.invokeExact(mbedtlsSslConfig, len, ignoreOtherCids) as Int
+
+    private val H_set_cid = handle("mbedtls_ssl_set_cid", FunctionDescriptor.of(INT, ADDRESS, INT, ADDRESS, INT))
+    fun mbedtls_ssl_set_cid(sslContext: MemorySegment, enable: Int, ownCid: ByteArray, ownCidLen: Int): Int = Arena.ofConfined().use { arena -> mbedtls_ssl_set_cid_native(sslContext, enable, arena.copyOf(ownCid), ownCidLen) }
+
+    private fun mbedtls_ssl_set_cid_native(sslContext: MemorySegment, enable: Int, ownCid: MemorySegment, ownCidLen: Int): Int = H_set_cid.invokeExact(sslContext, enable, ownCid, ownCidLen) as Int
+
+    private val H_get_peer_cid = handle("mbedtls_ssl_get_peer_cid", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_get_peer_cid(sslContext: MemorySegment, enabled: MemorySegment, peerCid: MemorySegment, peerCidLen: MemorySegment): Int = H_get_peer_cid.invokeExact(sslContext, enabled, peerCid, peerCidLen) as Int
+
+    private val H_context_save = handle("mbedtls_ssl_context_save", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT, ADDRESS))
+    fun mbedtls_ssl_context_save(sslContext: MemorySegment, buf: ByteArray, bufLen: Int, outputLen: ByteArray): Int = Arena.ofConfined().use { arena ->
+        val bufSeg = arena.allocate(bufLen.toLong())
+        val olenSeg = arena.allocate(ValueLayout.JAVA_LONG)
+        val ret = mbedtls_ssl_context_save_native(sslContext, bufSeg, bufLen, olenSeg)
+        MemorySegment.copy(bufSeg, BYTE, 0L, buf, 0, bufLen)
+        // olen is a size_t; copy its low bytes into the caller's output buffer (mirrors the JNA layout)
+        MemorySegment.copy(olenSeg, BYTE, 0L, outputLen, 0, outputLen.size)
+        ret
+    }
+
+    private fun mbedtls_ssl_context_save_native(sslContext: MemorySegment, buf: MemorySegment, bufLen: Int, outputLen: MemorySegment): Int = H_context_save.invokeExact(sslContext, buf, bufLen, outputLen) as Int
+
+    private val H_context_load = handle("mbedtls_ssl_context_load", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+    fun mbedtls_ssl_context_load(sslContext: MemorySegment, buf: ByteArray, len: Int): Int = Arena.ofConfined().use { arena -> mbedtls_ssl_context_load_native(sslContext, arena.copyOf(buf), len) }
+
+    private fun mbedtls_ssl_context_load_native(sslContext: MemorySegment, buf: MemorySegment, len: Int): Int = H_context_load.invokeExact(sslContext, buf, len) as Int
+
+    private val H_check_record = handle("mbedtls_ssl_check_record", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+    fun mbedtls_ssl_check_record(sslContext: MemorySegment, buf: MemorySegment, bufLen: Int): Int = H_check_record.invokeExact(sslContext, buf, bufLen) as Int
+
+    private val H_conf_ca_chain = handle("mbedtls_ssl_conf_ca_chain", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_conf_ca_chain(sslConfig: MemorySegment, caChain: MemorySegment, caCrl: MemorySegment) {
+        H_conf_ca_chain.invokeExact(sslConfig, caChain, caCrl)
+    }
+
+    private val H_conf_own_cert = handle("mbedtls_ssl_conf_own_cert", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_conf_own_cert(sslConfig: MemorySegment, ownCert: MemorySegment, pkKey: MemorySegment): Int = H_conf_own_cert.invokeExact(sslConfig, ownCert, pkKey) as Int
+
+    private val H_set_mtu = handle("mbedtls_ssl_set_mtu", FunctionDescriptor.ofVoid(ADDRESS, INT))
+    fun mbedtls_ssl_set_mtu(sslContext: MemorySegment, mtu: Int) {
+        H_set_mtu.invokeExact(sslContext, mtu)
+    }
+
+    private val H_get_peer_cert = handle("mbedtls_ssl_get_peer_cert", FunctionDescriptor.of(ADDRESS, ADDRESS))
+    fun mbedtls_ssl_get_peer_cert(sslContext: MemorySegment): MemorySegment? {
+        val ptr = H_get_peer_cert.invokeExact(sslContext) as MemorySegment
+        return if (ptr.address() == 0L) null else ptr
+    }
+
+    private val H_set_hostname = handle("mbedtls_ssl_set_hostname", FunctionDescriptor.of(INT, ADDRESS, ADDRESS))
+    fun mbedtls_ssl_set_hostname(sslContext: MemorySegment, hostname: String?): Int = Arena.ofConfined().use { arena ->
+        val hostnameSeg = if (hostname == null) MemorySegment.NULL else arena.allocateFrom(hostname)
+        mbedtls_ssl_set_hostname_native(sslContext, hostnameSeg)
+    }
+
+    private fun mbedtls_ssl_set_hostname_native(sslContext: MemorySegment, hostname: MemorySegment): Int = H_set_hostname.invokeExact(sslContext, hostname) as Int
 
     const val MBEDTLS_ERR_SSL_TIMEOUT = -0x6800
     const val MBEDTLS_ERR_SSL_WANT_READ = -0x6900
@@ -92,20 +252,38 @@ internal object MbedtlsApi {
     const val MBEDTLS_ERR_SSL_UNEXPECTED_RECORD = -0x6700
 
     // ----- net_sockets.h -----
-    val MBEDTLS_ERR_NET_RECV_FAILED = -0x004C
-    val MBEDTLS_ERR_NET_SEND_FAILED = -0x004E
+    const val MBEDTLS_ERR_NET_RECV_FAILED = -0x004C
+    const val MBEDTLS_ERR_NET_SEND_FAILED = -0x004E
 
     // mbedtls/debug.h
-    external fun mbedtls_debug_set_threshold(threshold: Int)
+    private val H_debug_set_threshold = handle("mbedtls_debug_set_threshold", FunctionDescriptor.ofVoid(INT))
+    fun mbedtls_debug_set_threshold(threshold: Int) {
+        H_debug_set_threshold.invokeExact(threshold)
+    }
 
     // mbedtls/ssl_cookie.h
-    external fun mbedtls_ssl_cookie_init(cookieCtx: Pointer)
-    external fun mbedtls_ssl_cookie_free(cookieCtx: Pointer)
-    external fun mbedtls_ssl_cookie_setup(cookieCtx: Pointer): Int
-    val mbedtls_ssl_cookie_write: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_write")
-    val mbedtls_ssl_cookie_check: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_check")
+    private val H_cookie_init = handle("mbedtls_ssl_cookie_init", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_cookie_init(cookieCtx: MemorySegment) {
+        H_cookie_init.invokeExact(cookieCtx)
+    }
+
+    private val H_cookie_free = handle("mbedtls_ssl_cookie_free", FunctionDescriptor.ofVoid(ADDRESS))
+    fun mbedtls_ssl_cookie_free(cookieCtx: MemorySegment) {
+        H_cookie_free.invokeExact(cookieCtx)
+    }
+
+    private val H_cookie_setup = handle("mbedtls_ssl_cookie_setup", FunctionDescriptor.of(INT, ADDRESS))
+    fun mbedtls_ssl_cookie_setup(cookieCtx: MemorySegment): Int = H_cookie_setup.invokeExact(cookieCtx) as Int
+
+    // Passed by address (no upcall): the native function pointers themselves.
+    val mbedtls_ssl_cookie_write: MemorySegment = symbol("mbedtls_ssl_cookie_write")
+    val mbedtls_ssl_cookie_check: MemorySegment = symbol("mbedtls_ssl_cookie_check")
 
     // -------------------------
+
+    init {
+        configureLogThreshold()
+    }
 
     internal fun Int.verify(): Int {
         if (this >= 0) return this
@@ -128,22 +306,54 @@ internal object MbedtlsApi {
 
     internal object Crypto {
         // mbedtls/pk.h
-        external fun mbedtls_pk_init(ctx: Pointer)
-        external fun mbedtls_pk_free(ctx: Pointer)
-        external fun mbedtls_pk_parse_key(ctx: Pointer, key: ByteArray, keyLen: Int, pwd: Pointer?, pwdLen: Int): Int
+        private val H_pk_init = handle("mbedtls_pk_init", FunctionDescriptor.ofVoid(ADDRESS))
+        fun mbedtls_pk_init(ctx: MemorySegment) {
+            H_pk_init.invokeExact(ctx)
+        }
+
+        private val H_pk_free = handle("mbedtls_pk_free", FunctionDescriptor.ofVoid(ADDRESS))
+        fun mbedtls_pk_free(ctx: MemorySegment) {
+            H_pk_free.invokeExact(ctx)
+        }
+
+        private val H_pk_parse_key = handle("mbedtls_pk_parse_key", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT, ADDRESS, INT))
+        fun mbedtls_pk_parse_key(ctx: MemorySegment, key: ByteArray, keyLen: Int, pwd: MemorySegment, pwdLen: Int): Int = Arena.ofConfined().use { arena -> mbedtls_pk_parse_key_native(ctx, arena.copyOf(key), keyLen, pwd, pwdLen) }
+
+        private fun mbedtls_pk_parse_key_native(ctx: MemorySegment, key: MemorySegment, keyLen: Int, pwd: MemorySegment, pwdLen: Int): Int = H_pk_parse_key.invokeExact(ctx, key, keyLen, pwd, pwdLen) as Int
 
         // psa/crypto.h
-        external fun psa_crypto_init(): Int
+        private val H_psa_crypto_init = handle("psa_crypto_init", FunctionDescriptor.of(INT))
+        fun psa_crypto_init(): Int = H_psa_crypto_init.invokeExact() as Int
     }
 
     internal object X509 {
-
         // mbedtls/x509_crt.h
-        external fun mbedtls_x509_crt_init(cert: Pointer)
-        external fun mbedtls_x509_crt_free(cert: Pointer)
-        external fun mbedtls_x509_crt_parse_der(chain: Pointer, buf: ByteArray, len: Int): Int
+        private val H_crt_init = handle("mbedtls_x509_crt_init", FunctionDescriptor.ofVoid(ADDRESS))
+        fun mbedtls_x509_crt_init(cert: MemorySegment) {
+            H_crt_init.invokeExact(cert)
+        }
+
+        private val H_crt_free = handle("mbedtls_x509_crt_free", FunctionDescriptor.ofVoid(ADDRESS))
+        fun mbedtls_x509_crt_free(cert: MemorySegment) {
+            H_crt_free.invokeExact(cert)
+        }
+
+        private val H_crt_parse_der = handle("mbedtls_x509_crt_parse_der", FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT))
+        fun mbedtls_x509_crt_parse_der(chain: MemorySegment, buf: ByteArray, len: Int): Int = Arena.ofConfined().use { arena -> mbedtls_x509_crt_parse_der_native(chain, arena.copyOf(buf), len) }
+
+        private fun mbedtls_x509_crt_parse_der_native(chain: MemorySegment, buf: MemorySegment, len: Int): Int = H_crt_parse_der.invokeExact(chain, buf, len) as Int
 
         // mbedtls/error.h
-        external fun mbedtls_strerror(errnum: Int, buffer: Pointer, buflen: Int)
+        private val H_strerror = handle("mbedtls_strerror", FunctionDescriptor.ofVoid(INT, ADDRESS, INT))
+        fun mbedtls_strerror(errnum: Int, buffer: MemorySegment, buflen: Int) {
+            H_strerror.invokeExact(errnum, buffer, buflen)
+        }
     }
+}
+
+private const val MAX_C_STRING_BYTES = 4096L
+
+internal fun MemorySegment.readCString(): String {
+    if (address() == 0L) return ""
+    return reinterpret(MAX_C_STRING_BYTES).getString(0L)
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsNativeLoader.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsNativeLoader.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl
+
+import java.lang.foreign.Arena
+import java.lang.foreign.SymbolLookup
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/*
+Loads the bundled mbedtls native libraries using the Foreign Function & Memory API.
+
+The three platform libraries are extracted from `mbedtls-lib` resources into a single temp directory and
+loaded by absolute path, in dependency order (tfpsacrypto -> mbedx509 -> mbedtls), into a long-lived global
+Arena. Loading dependencies first lets the dynamic linker satisfy inter-library symbols via SONAME matching,
+so RTLD_GLOBAL is not required.
+ */
+internal object MbedtlsNativeLoader {
+
+    // Dependencies must be loaded before the libraries that need them.
+    private val LIB_NAMES = listOf("tfpsacrypto", "mbedx509", "mbedtls")
+
+    // Combined lookup across all three libraries.
+    val lookup: SymbolLookup by lazy { load() }
+
+    private fun load(): SymbolLookup {
+        val arena = Arena.global()
+        val platform = Platform.current()
+        val tempDir = Files.createTempDirectory("kotlin-mbedtls").also { it.toFile().deleteOnExit() }
+
+        var combined: SymbolLookup? = null
+        for (name in LIB_NAMES) {
+            val libFile = extract(platform, name, tempDir)
+            val libLookup = SymbolLookup.libraryLookup(libFile, arena)
+            combined = combined?.or(libLookup) ?: libLookup
+        }
+        return combined ?: error("No mbedtls native libraries were loaded")
+    }
+
+    private fun extract(platform: Platform, name: String, tempDir: Path): Path {
+        val fileName = "${platform.prefix}$name${platform.suffix}"
+        val resourcePath = "/${platform.resourceDir}/$fileName"
+        val target = tempDir.resolve(fileName)
+
+        val input = javaClass.getResourceAsStream(resourcePath)
+            ?: throw UnsatisfiedLinkError("Bundled native library not found on classpath: $resourcePath")
+        input.use { Files.copy(it, target, StandardCopyOption.REPLACE_EXISTING) }
+        target.toFile().deleteOnExit()
+        return target
+    }
+
+    private data class Platform(val resourceDir: String, val prefix: String, val suffix: String) {
+        companion object {
+            fun current(): Platform {
+                val os = System.getProperty("os.name").lowercase()
+                val arch = System.getProperty("os.arch").lowercase()
+                return when {
+                    os.contains("mac") || os.contains("darwin") -> Platform("darwin", "lib", ".dylib")
+                    os.contains("win") -> Platform("win32-x86-64", "lib", ".dll")
+                    os.contains("nux") || os.contains("nix") -> {
+                        val isArm = arch.contains("aarch64") || arch.contains("arm64")
+                        Platform(if (isArm) "linux-aarch64" else "linux-x86-64", "lib", ".so")
+                    }
+
+                    else -> throw UnsatisfiedLinkError("Unsupported platform: os=$os arch=$arch")
+                }
+            }
+        }
+    }
+}

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/ReceiveCallback.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/ReceiveCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,40 @@
 
 package org.opencoap.ssl
 
-import com.sun.jna.Callback
-import com.sun.jna.Pointer
 import org.slf4j.LoggerFactory
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
 import java.nio.ByteBuffer
 
-internal object ReceiveCallback : Callback {
+private val ADDRESS = ValueLayout.ADDRESS
+private val INT = ValueLayout.JAVA_INT
+
+internal object ReceiveCallback {
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val buffer = ThreadLocal<ByteBuffer>()
     private val timeout = ThreadLocal<Int>()
+
+    // mbedtls bio: int f_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t timeout)
+    val stub: MemorySegment = run {
+        val mh = MethodHandles.lookup().findVirtual(
+            ReceiveCallback::class.java,
+            "callback",
+            MethodType.methodType(
+                Int::class.javaPrimitiveType,
+                MemorySegment::class.java,
+                MemorySegment::class.java,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType
+            )
+        ).bindTo(this)
+        Linker.nativeLinker().upcallStub(mh, FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT, INT), Arena.global())
+    }
 
     operator fun <T> invoke(buf: ByteBuffer?, readFun: () -> T): T {
         this.buffer.set(buf)
@@ -39,7 +63,7 @@ internal object ReceiveCallback : Callback {
 
     fun timeout(): Int = timeout.get() ?: 0
 
-    fun callback(ctx: Pointer?, bufPointer: Pointer, len: Int, timeout: Int): Int {
+    fun callback(ctx: MemorySegment, bufPointer: MemorySegment, len: Int, timeout: Int): Int {
         val buffer = this.buffer.get()
         this.buffer.remove()
         this.timeout.set(timeout)
@@ -53,14 +77,15 @@ internal object ReceiveCallback : Callback {
                     val size = buffer.remaining().coerceAtMost(len)
                     buffer.limit(buffer.position() + size)
                     bufPointer
-                        .getByteBuffer(0, len.toLong())
+                        .reinterpret(len.toLong())
+                        .asByteBuffer()
                         .put(buffer)
 
                     size
                 }
             }
         } catch (e: Exception) {
-            // need to catch all exceptions to avoid crashing
+            // need to catch all exceptions to avoid crashing at the native boundary
             logger.error(e.message, e)
         }
         return MbedtlsApi.MBEDTLS_ERR_NET_RECV_FAILED
@@ -69,9 +94,24 @@ internal object ReceiveCallback : Callback {
 
 internal typealias SendBytes = (ByteBuffer) -> Unit
 
-internal object SendCallback : Callback {
+internal object SendCallback {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val sendFunc = ThreadLocal<SendBytes>()
+
+    // mbedtls bio: int f_send(void *ctx, const unsigned char *buf, size_t len)
+    val stub: MemorySegment = run {
+        val mh = MethodHandles.lookup().findVirtual(
+            SendCallback::class.java,
+            "callback",
+            MethodType.methodType(
+                Int::class.javaPrimitiveType,
+                MemorySegment::class.java,
+                MemorySegment::class.java,
+                Int::class.javaPrimitiveType
+            )
+        ).bindTo(this)
+        Linker.nativeLinker().upcallStub(mh, FunctionDescriptor.of(INT, ADDRESS, ADDRESS, INT), Arena.global())
+    }
 
     operator fun <T> invoke(send: SendBytes, run: () -> T): T {
         sendFunc.set(send)
@@ -88,14 +128,14 @@ internal object SendCallback : Callback {
         return sendBuf
     }
 
-    fun callback(ctx: Pointer?, buf: Pointer, len: Int): Int {
+    fun callback(ctx: MemorySegment, buf: MemorySegment, len: Int): Int {
         try {
             sendFunc.get()?.also {
-                it.invoke(buf.getByteBuffer(0, len.toLong()))
+                it.invoke(buf.reinterpret(len.toLong()).asByteBuffer())
                 return len
             }
         } catch (e: java.lang.Exception) {
-            // need to catch all exceptions to avoid crashing
+            // need to catch all exceptions to avoid crashing at the native boundary
             logger.error(e.message, e)
         }
         return MbedtlsApi.MBEDTLS_ERR_NET_SEND_FAILED

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslConfig.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.opencoap.ssl
 
-import com.sun.jna.Callback
-import com.sun.jna.Memory
-import com.sun.jna.Pointer
 import org.opencoap.ssl.MbedtlsApi.Crypto.mbedtls_pk_free
 import org.opencoap.ssl.MbedtlsApi.Crypto.mbedtls_pk_parse_key
 import org.opencoap.ssl.MbedtlsApi.Crypto.psa_crypto_init
@@ -51,14 +48,25 @@ import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_setup
 import org.opencoap.ssl.MbedtlsApi.verify
 import org.slf4j.LoggerFactory
 import java.io.Closeable
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
 import java.net.InetSocketAddress
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.time.Duration.ofSeconds
 
+private const val STRUCT_ALIGNMENT = 16L
+
+internal fun Arena.allocStruct(size: Long): MemorySegment = allocate(size, STRUCT_ALIGNMENT)
+
 class SslConfig(
-    private val conf: Memory,
+    private val conf: MemorySegment,
     val cidSupplier: CidSupplier?,
     private val mtu: Int,
     private val close: Closeable
@@ -66,10 +74,11 @@ class SslConfig(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     fun newContext(peerAddress: InetSocketAddress): SslHandshakeContext {
-        val sslContext = Memory(MbedtlsSizeOf.mbedtls_ssl_context).apply(MbedtlsApi::mbedtls_ssl_init)
+        val arena = Arena.ofShared()
+        val sslContext = arena.allocStruct(MbedtlsSizeOf.mbedtls_ssl_context).also(MbedtlsApi::mbedtls_ssl_init)
 
         mbedtls_ssl_setup(sslContext, conf).verify()
-        mbedtls_ssl_set_timer_cb(sslContext, Pointer.NULL, NoOpsSetDelayCallback, NoOpsGetDelayCallback)
+        mbedtls_ssl_set_timer_cb(sslContext, MemorySegment.NULL, NoOpsSetDelayCallback.stub, NoOpsGetDelayCallback.stub)
 
         val cid = cidSupplier?.next()
         if (cid != null) {
@@ -81,19 +90,20 @@ class SslConfig(
         mbedtls_ssl_set_client_transport_id(sslContext, clientId, clientId.length)
         mbedtls_ssl_set_hostname(sslContext, null).verify()
 
-        mbedtls_ssl_set_bio(sslContext, Pointer.NULL, SendCallback, null, ReceiveCallback)
+        mbedtls_ssl_set_bio(sslContext, MemorySegment.NULL, SendCallback.stub, MemorySegment.NULL, ReceiveCallback.stub)
 
-        return SslHandshakeContext(this, sslContext, cid, peerAddress)
+        return SslHandshakeContext(this, arena, sslContext, cid, peerAddress)
     }
 
     fun loadSession(cid: ByteArray, session: ByteArray, peerAddress: InetSocketAddress): SslSession {
-        val sslContext = Memory(MbedtlsSizeOf.mbedtls_ssl_context).apply(MbedtlsApi::mbedtls_ssl_init)
+        val arena = Arena.ofShared()
+        val sslContext = arena.allocStruct(MbedtlsSizeOf.mbedtls_ssl_context).also(MbedtlsApi::mbedtls_ssl_init)
 
         mbedtls_ssl_setup(sslContext, conf).verify()
         mbedtls_ssl_context_load(sslContext, session, session.size).verify()
-        mbedtls_ssl_set_bio(sslContext, Pointer.NULL, SendCallback, null, ReceiveCallback)
+        mbedtls_ssl_set_bio(sslContext, MemorySegment.NULL, SendCallback.stub, MemorySegment.NULL, ReceiveCallback.stub)
 
-        return SslSession(this, sslContext, cid, true).also {
+        return SslSession(this, arena, sslContext, cid, true).also {
             logger.info("[{}] [{}] DTLS session reloaded {}", peerAddress, cid, it)
         }
     }
@@ -108,6 +118,7 @@ class SslConfig(
         @JvmOverloads
         fun server(auth: AuthConfig, cipherSuites: List<String> = emptyList(), reqAuthentication: Boolean = true, cidSupplier: CidSupplier? = EmptyCidSupplier, mtu: Int = 0, retransmitMin: Duration = ofSeconds(1), retransmitMax: Duration = ofSeconds(60)): SslConfig = create(true, auth, cipherSuites, cidSupplier, reqAuthentication, mtu, retransmitMin, retransmitMax)
 
+        @Suppress("LongParameterList")
         private fun create(
             isServer: Boolean,
             authConfig: AuthConfig,
@@ -118,11 +129,11 @@ class SslConfig(
             retransmitMin: Duration,
             retransmitMax: Duration
         ): SslConfig {
-            val sslConfig = Memory(MbedtlsSizeOf.mbedtls_ssl_config).also(MbedtlsApi::mbedtls_ssl_config_init)
-            val ownCert = Memory(MbedtlsSizeOf.mbedtls_x509_crt).also(MbedtlsApi.X509::mbedtls_x509_crt_init)
-            val caCert = Memory(MbedtlsSizeOf.mbedtls_x509_crt).also(MbedtlsApi.X509::mbedtls_x509_crt_init)
-            val pkey = Memory(MbedtlsSizeOf.mbedtls_pk_context).also(MbedtlsApi.Crypto::mbedtls_pk_init)
-            var cipherSuiteIds: Memory? = null
+            val arena = Arena.ofShared()
+            val sslConfig = arena.allocStruct(MbedtlsSizeOf.mbedtls_ssl_config).also(MbedtlsApi::mbedtls_ssl_config_init)
+            val ownCert = arena.allocStruct(MbedtlsSizeOf.mbedtls_x509_crt).also(MbedtlsApi.X509::mbedtls_x509_crt_init)
+            val caCert = arena.allocStruct(MbedtlsSizeOf.mbedtls_x509_crt).also(MbedtlsApi.X509::mbedtls_x509_crt_init)
+            val pkey = arena.allocStruct(MbedtlsSizeOf.mbedtls_pk_context).also(MbedtlsApi.Crypto::mbedtls_pk_init)
 
             // Initialize PSA Crypto subsystem (required in MbedTLS 4.0+)
             psa_crypto_init().verify()
@@ -130,19 +141,18 @@ class SslConfig(
             mbedtls_ssl_config_defaults(sslConfig, endpointType, MbedtlsApi.MBEDTLS_SSL_TRANSPORT_DATAGRAM, MbedtlsApi.MBEDTLS_SSL_PRESET_DEFAULT).verify()
 
             // cookies
-            var cookieCtx: Memory? = null
+            var cookieCtx: MemorySegment? = null
             if (!isServer) {
-                mbedtls_ssl_conf_dtls_cookies(sslConfig, null, null, null)
+                mbedtls_ssl_conf_dtls_cookies(sslConfig, MemorySegment.NULL, MemorySegment.NULL, MemorySegment.NULL)
             } else {
-                cookieCtx = Memory(MbedtlsSizeOf.mbedtls_ssl_cookie_ctx).also(MbedtlsApi::mbedtls_ssl_cookie_init)
+                cookieCtx = arena.allocStruct(MbedtlsSizeOf.mbedtls_ssl_cookie_ctx).also(MbedtlsApi::mbedtls_ssl_cookie_init)
                 mbedtls_ssl_cookie_setup(cookieCtx).verify()
                 mbedtls_ssl_conf_dtls_cookies(sslConfig, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, cookieCtx)
             }
 
             mbedtls_ssl_conf_authmode(sslConfig, if (requiredAuthMode) MbedtlsApi.MBEDTLS_SSL_VERIFY_REQUIRED else MbedtlsApi.MBEDTLS_SSL_VERIFY_NONE)
             if (cipherSuites.isNotEmpty()) {
-                cipherSuiteIds = mapCipherSuites(cipherSuites)
-                mbedtls_ssl_conf_ciphersuites(sslConfig, cipherSuiteIds)
+                mbedtls_ssl_conf_ciphersuites(sslConfig, mapCipherSuites(arena, cipherSuites))
             }
 
             if (cidSupplier != null && cidSupplier != EmptyCidSupplier) {
@@ -155,25 +165,27 @@ class SslConfig(
             mbedtls_ssl_conf_handshake_timeout(sslConfig, retransmitMin.toMillis().toInt(), retransmitMax.toMillis().toInt())
 
             // Logging
-            mbedtls_ssl_conf_dbg(sslConfig, LogCallback, Pointer.NULL)
+            mbedtls_ssl_conf_dbg(sslConfig, LogCallback.stub, MemorySegment.NULL)
 
             return SslConfig(sslConfig, cidSupplier, mtu) {
                 mbedtls_ssl_config_free(sslConfig)
                 mbedtls_pk_free(pkey)
                 mbedtls_x509_crt_free(ownCert)
                 mbedtls_x509_crt_free(caCert)
-                cookieCtx?.also(::mbedtls_ssl_cookie_free)
-                cipherSuiteIds?.also { it.clear() }
+                cookieCtx?.also(MbedtlsApi::mbedtls_ssl_cookie_free)
+                arena.close()
             }
         }
 
-        private fun mapCipherSuites(cipherSuites: List<String>): Memory {
+        private fun mapCipherSuites(arena: Arena, cipherSuites: List<String>): MemorySegment {
             val ids = cipherSuites.map(Companion::getCipherSuiteId).toIntArray()
 
-            val cipherSuiteList = Memory(((ids.size + 1) * 4).toLong())
-            cipherSuiteList.write(0, ids, 0, ids.size)
-            cipherSuiteList.setInt(cipherSuiteList.size() - 4, 0)
-            return cipherSuiteList
+            val segment = arena.allocate(((ids.size + 1) * 4).toLong())
+            for (i in ids.indices) {
+                segment.setAtIndex(ValueLayout.JAVA_INT, i.toLong(), ids[i])
+            }
+            segment.setAtIndex(ValueLayout.JAVA_INT, ids.size.toLong(), 0)
+            return segment
         }
 
         private fun getCipherSuiteId(cipherSuite: String): Int {
@@ -183,44 +195,102 @@ class SslConfig(
         }
     }
 
-    private object LogCallback : Callback {
+    private object LogCallback {
         private val logger = LoggerFactory.getLogger(MbedtlsApi::class.java)
-        fun callback(ctx: Pointer?, debugLevel: Int, fileName: String, lineNumber: Int, message: String?) {
-            if (debugLevel == 1) {
-                // Introduced in MbedTLS 4.0.0: this log message should be at trace level, not warning
-                // These should be fixed in the next MbedTLS release of 4.x
-                if (message?.contains("Perform PSA-based ECDH computation") == true) return
-                if (message?.contains("<= mbedtls_ssl_check_record") == true) return
-                if (message?.contains("=> mbedtls_ssl_check_record") == true) return
 
-                // logs when close notify is received
-                if (message?.contains("mbedtls_ssl_handle_message_type() returned -30848 (-0x7880)") == true) return
-                if (message?.contains("mbedtls_ssl_read_record() returned -30848 (-0x7880)") == true) return
-            }
+        // void f_dbg(void *ctx, int level, const char *file, int line, const char *str)
+        val stub: MemorySegment = run {
+            val mh = MethodHandles.lookup().findVirtual(
+                LogCallback::class.java,
+                "callback",
+                MethodType.methodType(
+                    Void.TYPE,
+                    MemorySegment::class.java,
+                    Int::class.javaPrimitiveType,
+                    MemorySegment::class.java,
+                    Int::class.javaPrimitiveType,
+                    MemorySegment::class.java
+                )
+            ).bindTo(this)
+            Linker.nativeLinker().upcallStub(
+                mh,
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+                Arena.global()
+            )
+        }
 
-            when (debugLevel) {
-                1 -> logger.warn("[mbedtls {}:{}] {} ", fileName.substringAfterLast('/'), lineNumber, message?.trim())
-                2 -> logger.debug("[mbedtls {}:{}] {}", fileName.substringAfterLast('/'), lineNumber, message?.trim())
-                else -> logger.trace("[mbedtls {}:{}] {}", fileName.substringAfterLast('/'), lineNumber, message?.trim())
+        @Suppress("UnusedParameter")
+        private fun callback(ctx: MemorySegment, debugLevel: Int, file: MemorySegment, lineNumber: Int, str: MemorySegment) {
+            try {
+                val fileName = file.readCString()
+                val message = str.readCString()
+                if (debugLevel == 1) {
+                    // Introduced in MbedTLS 4.0.0: this log message should be at trace level, not warning
+                    // These should be fixed in the next MbedTLS release of 4.x
+                    if (message.contains("Perform PSA-based ECDH computation")) return
+                    if (message.contains("<= mbedtls_ssl_check_record")) return
+                    if (message.contains("=> mbedtls_ssl_check_record")) return
+
+                    // logs when close notify is received
+                    if (message.contains("mbedtls_ssl_handle_message_type() returned -30848 (-0x7880)")) return
+                    if (message.contains("mbedtls_ssl_read_record() returned -30848 (-0x7880)")) return
+                }
+
+                when (debugLevel) {
+                    1 -> logger.warn("[mbedtls {}:{}] {} ", fileName.substringAfterLast('/'), lineNumber, message.trim())
+                    2 -> logger.debug("[mbedtls {}:{}] {}", fileName.substringAfterLast('/'), lineNumber, message.trim())
+                    else -> logger.trace("[mbedtls {}:{}] {}", fileName.substringAfterLast('/'), lineNumber, message.trim())
+                }
+            } catch (e: Exception) {
+                // never let an exception cross the native boundary
+                logger.error(e.message, e)
             }
         }
     }
 
-    private object NoOpsSetDelayCallback : Callback {
+    private object NoOpsSetDelayCallback {
+        // void f_set_timer(void *ctx, uint32_t int_ms, uint32_t fin_ms)
+        val stub: MemorySegment = run {
+            val mh = MethodHandles.lookup().findVirtual(
+                NoOpsSetDelayCallback::class.java,
+                "callback",
+                MethodType.methodType(Void.TYPE, MemorySegment::class.java, Int::class.javaPrimitiveType, Int::class.javaPrimitiveType)
+            ).bindTo(this)
+            Linker.nativeLinker().upcallStub(
+                mh,
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT),
+                Arena.global()
+            )
+        }
+
         @Suppress("UnusedParameter")
-        fun callback(data: Pointer?, intermediateMs: Int, finalMs: Int) {
+        private fun callback(data: MemorySegment, intermediateMs: Int, finalMs: Int) {
             // do nothing
         }
     }
 
-    private object NoOpsGetDelayCallback : Callback {
+    private object NoOpsGetDelayCallback {
+        // int f_get_timer(void *ctx)
+        val stub: MemorySegment = run {
+            val mh = MethodHandles.lookup().findVirtual(
+                NoOpsGetDelayCallback::class.java,
+                "callback",
+                MethodType.methodType(Int::class.javaPrimitiveType, MemorySegment::class.java)
+            ).bindTo(this)
+            Linker.nativeLinker().upcallStub(
+                mh,
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+                Arena.global()
+            )
+        }
+
         @Suppress("FunctionOnlyReturningConstant", "UnusedParameter")
-        fun callback(data: Pointer?): Int = 1
+        private fun callback(data: MemorySegment): Int = 1
     }
 }
 
 sealed interface AuthConfig {
-    fun configure(sslConfig: Memory, caCert: Memory, ownCert: Memory, pkey: Memory)
+    fun configure(sslConfig: MemorySegment, caCert: MemorySegment, ownCert: MemorySegment, pkey: MemorySegment)
 }
 
 data class PskAuth(
@@ -230,7 +300,7 @@ data class PskAuth(
 
     constructor(pskId: String, pskSecret: ByteArray) : this(pskId.encodeToByteArray(), pskSecret)
 
-    override fun configure(sslConfig: Memory, caCert: Memory, ownCert: Memory, pkey: Memory) {
+    override fun configure(sslConfig: MemorySegment, caCert: MemorySegment, ownCert: MemorySegment, pkey: MemorySegment) {
         mbedtls_ssl_conf_psk(sslConfig, pskSecret, pskSecret.size, pskId, pskId.size).verify()
     }
 }
@@ -247,12 +317,12 @@ data class CertificateAuth(
     constructor(ownCertChain: List<X509Certificate>, privateKey: PrivateKey) :
         this(ownCertChain, privateKey, listOf())
 
-    override fun configure(sslConfig: Memory, caCert: Memory, ownCert: Memory, pkey: Memory) {
+    override fun configure(sslConfig: MemorySegment, caCert: MemorySegment, ownCert: MemorySegment, pkey: MemorySegment) {
         for (cert in trustedCerts) {
             val certDer = cert.encoded
             mbedtls_x509_crt_parse_der(caCert, certDer, certDer.size).verify()
         }
-        mbedtls_ssl_conf_ca_chain(sslConfig, caCert, Pointer.NULL)
+        mbedtls_ssl_conf_ca_chain(sslConfig, caCert, MemorySegment.NULL)
 
         // Own certificate
         for (cert in ownCertChain) {
@@ -260,7 +330,7 @@ data class CertificateAuth(
             mbedtls_x509_crt_parse_der(ownCert, certDer, certDer.size).verify()
         }
         if (privateKey != null) {
-            mbedtls_pk_parse_key(pkey, privateKey.encoded, privateKey.encoded.size, Pointer.NULL, 0)
+            mbedtls_pk_parse_key(pkey, privateKey.encoded, privateKey.encoded.size, MemorySegment.NULL, 0)
             mbedtls_ssl_conf_own_cert(sslConfig, ownCert, pkey)
         }
     }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -16,7 +16,6 @@
 
 package org.opencoap.ssl
 
-import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.MBEDTLS_ERR_SSL_UNEXPECTED_RECORD
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_close_notify
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_context_save
@@ -32,6 +31,9 @@ import org.opencoap.ssl.transport.cloneToMemory
 import org.opencoap.ssl.transport.toHex
 import org.slf4j.LoggerFactory
 import java.io.Closeable
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.security.cert.CertificateFactory
@@ -64,7 +66,8 @@ sealed interface SslContext : Closeable {
 
 class SslHandshakeContext internal constructor(
     private val conf: SslConfig, // keep in memory to prevent GC
-    private val sslContext: Memory,
+    private val arena: Arena,
+    private val sslContext: MemorySegment,
     private val cid: ByteArray?,
     private val peerAdr: InetSocketAddress,
 ) : SslContext {
@@ -88,7 +91,8 @@ class SslHandshakeContext internal constructor(
         return when (ret) {
             MbedtlsApi.MBEDTLS_ERR_SSL_WANT_READ -> return this
             MbedtlsApi.MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED -> throw HelloVerifyRequired
-            0 -> SslSession(conf, sslContext, cid).also {
+            // ownership of arena + sslContext transfers to the session; this handshake context is discarded without close()
+            0 -> SslSession(conf, arena, sslContext, cid).also {
                 finishTimestamp = System.currentTimeMillis()
                 logger.info("[{}] DTLS connected in {}ms {}", peerAdr, finishTimestamp - startTimestamp, it)
             }
@@ -103,14 +107,20 @@ class SslHandshakeContext internal constructor(
     val readTimeout: Duration
         get() = stepTimeout
 
+    private var closed = false
+
     override fun close() {
+        if (closed) return
+        closed = true
         mbedtls_ssl_free(sslContext)
+        arena.close()
     }
 }
 
 class SslSession internal constructor(
     private val conf: SslConfig, // keep in memory to prevent GC
-    private val sslContext: Memory,
+    private val arena: Arena,
+    private val sslContext: MemorySegment,
     private val cid: ByteArray?,
     val reloaded: Boolean = false,
 ) : SslContext,
@@ -120,26 +130,29 @@ class SslSession internal constructor(
     val ownCid: ByteArray? = if (peerCid != null) cid else null
     val peerCertificateSubject: String? = readPeerCertificateSubject()
 
-    private fun readPeerCid(): ByteArray? {
-        val mem = Memory(16 + 64) // max cid len
-        mbedtls_ssl_get_peer_cid(sslContext, mem, mem.share(16), mem.share(8))
+    private fun readPeerCid(): ByteArray? = Arena.ofConfined().use { arena ->
+        val mem = arena.allocate(16 + 64L) // max cid len
+        // layout mirrors JNA: enabled (int) at 0, peer_cid_len (size_t) at 8, peer_cid bytes at 16
+        mbedtls_ssl_get_peer_cid(sslContext, mem, mem.asSlice(16L), mem.asSlice(8L))
 
-        if (mem.getInt(0) == 0) {
-            return null
+        if (mem.get(ValueLayout.JAVA_INT, 0L) == 0) {
+            null
+        } else {
+            val size = mem.get(ValueLayout.JAVA_INT, 8L)
+            val cidBytes = ByteArray(size)
+            MemorySegment.copy(mem, ValueLayout.JAVA_BYTE, 16L, cidBytes, 0, size)
+            cidBytes
         }
-        val size = mem.getInt(8)
-
-        return mem.getByteArray(16, size)
     }
 
     private fun readPeerCertificateSubject(): String? {
-        val pointer = mbedtls_ssl_get_peer_cert(sslContext)
-            ?.share(MbedtlsOffsetOf.mbedtls_x509_crt__raw)
-            ?: return null
+        val cert = mbedtls_ssl_get_peer_cert(sslContext) ?: return null
+        val crt = cert.reinterpret(MbedtlsSizeOf.mbedtls_x509_crt)
 
-        val derLen = pointer.getInt(MbedtlsOffsetOf.mbedtls_x509_buf__len)
-        val derPointer = pointer.getPointer(MbedtlsOffsetOf.mbedtls_x509_buf__len + 8)
-        val der = derPointer.getByteArray(0, derLen)
+        val rawOffset = MbedtlsOffsetOf.mbedtls_x509_crt__raw
+        val derLen = crt.get(ValueLayout.JAVA_INT, rawOffset + MbedtlsOffsetOf.mbedtls_x509_buf__len)
+        val derPointer = crt.get(ValueLayout.ADDRESS, rawOffset + MbedtlsOffsetOf.mbedtls_x509_buf__len + 8)
+        val der = derPointer.reinterpret(derLen.toLong()).toArray(ValueLayout.JAVA_BYTE)
 
         return try {
             val factory = CertificateFactory.getInstance("X.509")
@@ -165,17 +178,13 @@ class SslSession internal constructor(
         plainBuffer.limit(size + plainBuffer.position())
     }
 
-    fun checkRecord(encBuffer: ByteBuffer): VerificationResult {
-        val memory = encBuffer.cloneToMemory()
-        try {
-            val result = MbedtlsApi.mbedtls_ssl_check_record(sslContext, memory, memory.size().toInt())
-            return if (result == 0 || result != MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) {
-                VerificationResult.Valid("Success")
-            } else {
-                VerificationResult.Invalid(SslException.from(result).localizedMessage)
-            }
-        } finally {
-            memory.close()
+    fun checkRecord(encBuffer: ByteBuffer): VerificationResult = Arena.ofConfined().use { arena ->
+        val memory = encBuffer.cloneToMemory(arena)
+        val result = MbedtlsApi.mbedtls_ssl_check_record(sslContext, memory, memory.byteSize().toInt())
+        if (result == 0 || result != MBEDTLS_ERR_SSL_UNEXPECTED_RECORD) {
+            VerificationResult.Valid("Success")
+        } else {
+            VerificationResult.Invalid(SslException.from(result).localizedMessage)
         }
     }
 
@@ -223,8 +232,13 @@ class SslSession internal constructor(
         mbedtls_ssl_close_notify(sslContext)
     } ?: ByteBuffer.allocate(0)
 
+    private var closed = false
+
     override fun close() {
+        if (closed) return
+        closed = true
         mbedtls_ssl_free(sslContext)
+        arena.close()
     }
 
     sealed interface VerificationResult {

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
@@ -16,8 +16,8 @@
 
 package org.opencoap.ssl
 
-import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.X509.mbedtls_strerror
+import java.lang.foreign.Arena
 import java.util.Locale
 
 open class SslException(message: String) : Exception(message) {
@@ -28,11 +28,13 @@ open class SslException(message: String) : Exception(message) {
             else -> SslException(String.format(Locale.US, "%s [-0x%04X]", translateError(error), -error))
         }
 
-        internal fun translateError(error: Int): String {
-            val buffer = Memory(100)
-            mbedtls_strerror(error, buffer, buffer.size().toInt())
-            return buffer.getString(0).trim()
+        internal fun translateError(error: Int): String = Arena.ofConfined().use { arena ->
+            val buffer = arena.allocate(BUFFER_SIZE)
+            mbedtls_strerror(error, buffer, BUFFER_SIZE.toInt())
+            buffer.getString(0).trim()
         }
+
+        private const val BUFFER_SIZE = 100L
     }
 }
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/BytesExtensions.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/BytesExtensions.kt
@@ -16,7 +16,8 @@
 
 package org.opencoap.ssl.transport
 
-import com.sun.jna.Memory
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
 import java.nio.ByteBuffer
 
 internal fun ByteArray.toHex(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
@@ -28,14 +29,13 @@ fun ByteBuffer.copy(): ByteBuffer {
     return bb
 }
 
-fun ByteBuffer.cloneToMemory(): Memory {
+fun ByteBuffer.cloneToMemory(arena: Arena): MemorySegment {
     this.mark() // saves the original position
     val remaining = this.remaining()
-    val memory = Memory(remaining.toLong())
-    val intermediateBuffer: ByteBuffer = memory.getByteBuffer(0, remaining.toLong())
-    intermediateBuffer.put(this)
+    val segment = arena.allocate(remaining.toLong())
+    segment.asByteBuffer().put(this)
     this.reset()
-    return memory
+    return segment
 }
 
 fun ByteBuffer.isNotEmpty(): Boolean = this.hasRemaining()

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeMemoryLeakTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeMemoryLeakTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.opencoap.ssl.transport.decodeToString
+import org.opencoap.ssl.transport.toByteBuffer
+import org.opencoap.ssl.util.localAddress
+import org.opencoap.ssl.util.runGC
+import java.nio.ByteBuffer
+
+/**
+ * Verifies deterministic native-memory release (Scenario 3): closing an [SslConfig]/[SslSession] closes its backing
+ * [java.lang.foreign.Arena] and frees the native struct chain immediately, and repeated create/close cycles under GC
+ * stress neither leak nor crash.
+ */
+class NativeMemoryLeakTest {
+
+    private fun newConfigs(): Pair<SslConfig, SslConfig> {
+        val server = SslConfig.server(
+            PskAuth("device-007", byteArrayOf(0x01, 0x02)),
+            cipherSuites = listOf("TLS-PSK-WITH-AES-128-CCM"),
+            reqAuthentication = false,
+            cidSupplier = RandomCidSupplier(16)
+        )
+        val client = SslConfig.client(
+            PskAuth("device-007", byteArrayOf(0x01, 0x02)),
+            cipherSuites = listOf("TLS-PSK-WITH-AES-128-CCM"),
+            reqAuthentication = false,
+            cidSupplier = RandomCidSupplier(16)
+        )
+        return client to server
+    }
+
+    private fun handshake(clientConf: SslConfig, serverConf: SslConfig): Pair<SslSession, SslSession> {
+        lateinit var sendingBuffer: ByteBuffer
+        val send: (ByteBuffer) -> Unit = { sendingBuffer = it }
+        var srvHandshake = serverConf.newContext(localAddress(1_5684))
+        val cliHandshake = clientConf.newContext(localAddress(2_5684))
+
+        var clientSession: SslContext = cliHandshake
+        cliHandshake.step(send)
+        try {
+            srvHandshake.step(sendingBuffer) { clientSession = cliHandshake.step(it, send) }
+        } catch (ex: HelloVerifyRequired) {
+            srvHandshake.close()
+            srvHandshake = serverConf.newContext(localAddress(1_5684))
+        }
+        srvHandshake.step(sendingBuffer) { clientSession = cliHandshake.step(it, send) }
+        val serverSession = srvHandshake.step(sendingBuffer) { clientSession = cliHandshake.step(it, send) }
+
+        return (clientSession as SslSession) to (serverSession as SslSession)
+    }
+
+    @Test
+    fun `should release native memory deterministically on close`() {
+        val (clientConf, serverConf) = newConfigs()
+        val (clientSession, serverSession) = handshake(clientConf, serverConf)
+
+        // sanity: the session is usable before close
+        val enc = clientSession.encrypt("hello".toByteBuffer())
+        assertEquals("hello", serverSession.decrypt(enc) { }.decodeToString())
+
+        clientSession.close()
+        serverSession.close()
+        clientConf.close()
+        serverConf.close()
+
+        // closing twice must be a no-op (arena already closed, no double-free)
+        clientSession.close()
+        serverSession.close()
+
+        // touching a closed session must fail because its backing arena is closed -> memory was released
+        assertThrows(IllegalStateException::class.java) { clientSession.encrypt("again".toByteBuffer()) }
+    }
+
+    @Test
+    fun `should not leak native memory across create-close cycles under GC stress`() {
+        val cycles = 300
+        repeat(cycles) {
+            val (clientConf, serverConf) = newConfigs()
+            val (clientSession, serverSession) = handshake(clientConf, serverConf)
+
+            val enc = clientSession.encrypt("payload".toByteBuffer())
+            assertEquals("payload", serverSession.decrypt(enc) { }.decodeToString())
+
+            clientSession.close()
+            serverSession.close()
+            clientConf.close()
+            serverConf.close()
+
+            if (it % 50 == 0) runGC()
+        }
+
+        // if arenas were not freed on close, the process would accumulate native memory and likely fail well before here
+        assertTrue(true)
+    }
+}

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/ReceiveCallbackTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/ReceiveCallbackTest.kt
@@ -16,23 +16,31 @@
 
 package org.opencoap.ssl
 
-import com.sun.jna.Memory
-import com.sun.jna.Pointer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.opencoap.ssl.transport.decodeToString
 import org.opencoap.ssl.transport.toByteBuffer
 import org.opencoap.ssl.util.toMemory
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
 import java.nio.ByteBuffer
 
 internal class ReceiveCallbackTest {
 
     private val send = SendCallback
+    private val arena = Arena.ofAuto()
+
+    private fun MemorySegment.readString(len: Int): String {
+        val bytes = ByteArray(len)
+        MemorySegment.copy(this, ValueLayout.JAVA_BYTE, 0L, bytes, 0, len)
+        return bytes.decodeToString()
+    }
 
     @Test
     fun noDataAvailable() {
-        val mem = Memory(100)
-        val ret = ReceiveCallback.callback(Pointer.NULL, mem, 100, 0)
+        val mem = arena.allocate(100)
+        val ret = ReceiveCallback.callback(MemorySegment.NULL, mem, 100, 0)
 
         assertEquals(MbedtlsApi.MBEDTLS_ERR_SSL_WANT_READ, ret)
     }
@@ -41,16 +49,16 @@ internal class ReceiveCallbackTest {
     fun `should copy data to pointer`() {
         // given
         val buf = "dupa".toByteBuffer()
-        val mem = Memory(100)
+        val mem = arena.allocate(100)
 
         // when
         val ret = ReceiveCallback.invoke(buf) {
-            ReceiveCallback.callback(Pointer.NULL, mem, 100, 0)
+            ReceiveCallback.callback(MemorySegment.NULL, mem, 100, 0)
         }
 
         // then
         assertEquals(4, ret)
-        assertEquals("dupa", mem.getByteArray(0, 4).decodeToString())
+        assertEquals("dupa", mem.readString(4))
     }
 
     @Test
@@ -60,25 +68,25 @@ internal class ReceiveCallbackTest {
         buf.put("aaadupa".encodeToByteArray())
         buf.flip()
         buf.position(3)
-        val mem = Memory(100)
+        val mem = arena.allocate(100)
 
         // when
         val ret = ReceiveCallback.invoke(buf) {
-            ReceiveCallback.callback(Pointer.NULL, mem, 2, 0)
+            ReceiveCallback.callback(MemorySegment.NULL, mem, 2, 0)
         }
 
         // then
         assertEquals(2, ret)
-        assertEquals("du", mem.getByteArray(0, ret).decodeToString())
+        assertEquals("du", mem.readString(ret))
 
         // and
-        assertEquals(MbedtlsApi.MBEDTLS_ERR_SSL_WANT_READ, ReceiveCallback.callback(Pointer.NULL, mem, 100, 0))
+        assertEquals(MbedtlsApi.MBEDTLS_ERR_SSL_WANT_READ, ReceiveCallback.callback(MemorySegment.NULL, mem, 100, 0))
     }
 
     @Test
     fun `should return sent bytes`() {
         val sentBuf = send.invoke {
-            assertEquals(4, send.callback(Pointer.NULL, "dupa".toMemory(), 4))
+            assertEquals(4, send.callback(MemorySegment.NULL, "dupa".toMemory(), 4))
         }
 
         assertEquals("dupa", sentBuf?.decodeToString())
@@ -88,8 +96,8 @@ internal class ReceiveCallbackTest {
     fun `should sent multiple times`() {
         var index = 0
         send.invoke({ index += 1 }, {
-            assertEquals(4, send.callback(Pointer.NULL, "dupa".toMemory(), 4))
-            assertEquals(4, send.callback(Pointer.NULL, "dupa2".toMemory(), 4))
+            assertEquals(4, send.callback(MemorySegment.NULL, "dupa".toMemory(), 4))
+            assertEquals(4, send.callback(MemorySegment.NULL, "dupa2".toMemory(), 4))
         })
 
         assertEquals(2, index)
@@ -97,6 +105,6 @@ internal class ReceiveCallbackTest {
 
     @Test
     fun `should return failed when called outside invoke scope`() {
-        assertEquals(MbedtlsApi.MBEDTLS_ERR_NET_SEND_FAILED, send.callback(Pointer.NULL, "dupa".toMemory(), 4))
+        assertEquals(MbedtlsApi.MBEDTLS_ERR_NET_SEND_FAILED, send.callback(MemorySegment.NULL, "dupa".toMemory(), 4))
     }
 }

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/BytesExtensionsTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/BytesExtensionsTest.kt
@@ -16,11 +16,13 @@
 
 package org.opencoap.ssl.transport
 
-import com.sun.jna.Memory
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
 import java.nio.ByteBuffer
 
 class BytesExtensionsTest {
@@ -82,10 +84,10 @@ class BytesExtensionsTest {
         val originalLimit = byteBuffer.limit()
         val originalCapacity = byteBuffer.capacity()
 
-        val memory: Memory = byteBuffer.cloneToMemory()
+        val memory: MemorySegment = byteBuffer.cloneToMemory(Arena.ofAuto())
 
         val clonedData = ByteArray(originalData.size)
-        memory.read(0, clonedData, 0, originalData.size)
+        MemorySegment.copy(memory, ValueLayout.JAVA_BYTE, 0L, clonedData, 0, originalData.size)
         assertArrayEquals(originalData, clonedData)
 
         assertEquals(originalPosition, byteBuffer.position(), "Buffer position should not change")

--- a/kotlin-mbedtls/src/testFixtures/kotlin/org/opencoap/ssl/util/Utils.kt
+++ b/kotlin-mbedtls/src/testFixtures/kotlin/org/opencoap/ssl/util/Utils.kt
@@ -16,10 +16,12 @@
 
 package org.opencoap.ssl.util
 
-import com.sun.jna.Memory
 import org.opencoap.ssl.transport.Transport
 import org.opencoap.ssl.transport.decodeToString
 import org.opencoap.ssl.transport.toByteBuffer
+import java.lang.foreign.Arena
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.ValueLayout
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
@@ -39,8 +41,11 @@ fun String.decodeHex(): ByteArray {
 
 fun <T> CompletableFuture<T>.await(timeout: Duration = 5.seconds): T = this.get(timeout.toMillis(), TimeUnit.MILLISECONDS)
 
-fun String.toMemory(): Memory = Memory(this.length.toLong()).also {
-    it.write(0, this.encodeToByteArray(), 0, this.length)
+fun String.toMemory(): MemorySegment {
+    val bytes = this.encodeToByteArray()
+    val segment = Arena.ofAuto().allocate(bytes.size.toLong())
+    MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0L, bytes.size)
+    return segment
 }
 
 fun runGC() {


### PR DESCRIPTION
Atomic cutover from the JNA native bridge to the JDK Foreign Function & Memory API (Panama), raising the minimum runtime to Java 25 and dropping the `net.java.dev.jna` dependency.

Closes #115