### PR TITLE
refactor(ci): trigger mbedtls update manually and fix its PR not running CI

### DIFF
--- a/.github/workflows/update-mbedtls.yml
+++ b/.github/workflows/update-mbedtls.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.PAT_GITHUB }}
           branch: update-mbedtls
           delete-branch: true
           commit-message: Update Mbedtls

--- a/.github/workflows/update-mbedtls.yml
+++ b/.github/workflows/update-mbedtls.yml
@@ -1,9 +1,7 @@
 name: update Mbedtls to the latest version
 
 on:
-  schedule: # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: '0 1 * * 1' # run every monday at 01:00
-  workflow_dispatch: # allow manual triggering if needed
+  workflow_dispatch: # manually triggered
 
 jobs:
   get-mbedtls-version:


### PR DESCRIPTION
The scheduled run opens its PR via create-pull-request using the default GITHUB_TOKEN, and GitHub Actions never fires push/pull_request events for commits authored by GITHUB_TOKEN (anti-recursion safeguard). Since ci.yml only triggers on push, every weekly auto-generated PR (e.g. #113) lands with no CI run and sits unverified. Switch to workflow_dispatch only, so updates are run deliberately and someone can push a follow-up commit under their own account to actually get CI to run on the resulting branch.