### PR TITLE
fix: bump handshake step read-interval fallback from 1s to 3s

### DIFF
--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsTransmitter.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsTransmitter.kt
@@ -110,7 +110,11 @@ class DtlsTransmitter private constructor(
                 return when (newSslContext) {
                     is SslSession -> completedFuture(newSslContext)
                     is SslHandshakeContext -> {
-                        val timeout = if (newSslContext.readTimeout.isZero) Duration.ofSeconds(1) else newSslContext.readTimeout
+                        // readTimeout of zero means mbedtls has no active retransmission timer for this
+                        // step (e.g. it's waiting on the peer, not scheduled to retransmit anything itself),
+                        // so it gives us no guidance on how long to wait. This loop still needs a concrete
+                        // duration to poll with, hence this fallback.
+                        val timeout = if (newSslContext.readTimeout.isZero) Duration.ofSeconds(3) else newSslContext.readTimeout
                         trans.receive(timeout).thenComposeAsync(::handleReceive, executor)
                     }
                 }


### PR DESCRIPTION
Flaky testFailedHandshake() on macOS CI: client's per-step receive wait timed out before the server's fatal alert arrived, surfacing as TimeoutException instead of the expected SslException.