### PR TITLE
fix(transport): make listen() receive loop survive handling exceptions

### DIFF
--- a/kotlin-mbedtls-netty/src/main/kotlin/org/opencoap/ssl/netty/NettyTransportAdapter.kt
+++ b/kotlin-mbedtls-netty/src/main/kotlin/org/opencoap/ssl/netty/NettyTransportAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import org.opencoap.ssl.SslConfig
 import org.opencoap.ssl.SslSession
 import org.opencoap.ssl.transport.SessionWriter
 import org.opencoap.ssl.transport.Transport
-import java.io.IOException
 import java.net.InetSocketAddress
+import java.nio.channels.ClosedChannelException
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -49,7 +49,7 @@ class NettyTransportAdapter(
 
     override fun receive(timeout: Duration): CompletableFuture<ByteBuf> {
         if (!channel.isActive) {
-            return CompletableFuture<ByteBuf>().apply { completeExceptionally(IOException("Channel closed")) }
+            return CompletableFuture<ByteBuf>().apply { completeExceptionally(ClosedChannelException()) }
         }
 
         val promise = inboundMessageReceiver.queue.poll()

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/Transport.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/Transport.kt
@@ -49,26 +49,6 @@ fun interface TransportOutbound<P> {
     fun send(packet: P): CompletableFuture<Boolean>
 }
 
-// strips the wrappers that CompletableFuture puts around a failure propagated from an upstream stage
-private fun Throwable.unwrapCompletion(): Throwable = when (this) {
-    is CompletionException, is ExecutionException -> cause ?: this
-    else -> this
-}
-
-/*
-Tells "handling of this packet blew up" (recoverable, keep reading) apart from "the transport is gone"
-(terminal, stop reading). Only a closed channel or a shut down executor mean that no further packet can
-ever arrive. Note that a cancelled receive is deliberately not terminal: some transports cancel the
-pending receive to signal a plain read timeout.
- */
-private fun Throwable.isTransportGone(): Boolean = when (this) {
-    is ClosedChannelException, // also covers AsynchronousCloseException and ClosedByInterruptException
-    is ClosedSelectorException,
-    is RejectedExecutionException -> true
-
-    else -> false
-}
-
 fun <P, T : Transport<P>> T.listen(handler: Consumer<P>, executor: Executor = Executor(Runnable::run)): T {
     val logger = LoggerFactory.getLogger(javaClass)
 
@@ -81,14 +61,15 @@ fun <P, T : Transport<P>> T.listen(handler: Consumer<P>, executor: Executor = Ex
             }
             // transport is still alive, only this packet blew up: log and keep reading
             logger.error("Listener failed to receive: {}", cause.toString(), cause)
-        } else if (packet != null) {
+        }
+
+        if (packet != null) {
             try {
                 handler.accept(packet)
             } catch (ex: Exception) {
                 logger.error(ex.toString(), ex)
             }
         }
-
         // continue
         try {
             receive(Duration.ofSeconds(5)).whenCompleteAsync(::handle, executor)
@@ -101,4 +82,19 @@ fun <P, T : Transport<P>> T.listen(handler: Consumer<P>, executor: Executor = Ex
     // start loop
     receive(Duration.ofSeconds(5)).whenComplete(::handle)
     return this
+}
+
+// strips the wrappers that CompletableFuture puts around a failure propagated from an upstream stage
+private fun Throwable.unwrapCompletion(): Throwable = when (this) {
+    is CompletionException, is ExecutionException -> cause ?: this
+    else -> this
+}
+
+// a cancelled receive is deliberately not here: some transports cancel the pending receive on a plain read timeout
+private fun Throwable.isTransportGone(): Boolean = when (this) {
+    is ClosedChannelException, // also covers AsynchronousCloseException and ClosedByInterruptException
+    is ClosedSelectorException,
+    is RejectedExecutionException -> true
+
+    else -> false
 }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/Transport.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/Transport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,14 @@ package org.opencoap.ssl.transport
 
 import org.slf4j.LoggerFactory
 import java.io.Closeable
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.ClosedSelectorException
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
 import java.util.function.Consumer
 
 interface Transport<P> :
@@ -44,24 +49,53 @@ fun interface TransportOutbound<P> {
     fun send(packet: P): CompletableFuture<Boolean>
 }
 
+// strips the wrappers that CompletableFuture puts around a failure propagated from an upstream stage
+private fun Throwable.unwrapCompletion(): Throwable = when (this) {
+    is CompletionException, is ExecutionException -> cause ?: this
+    else -> this
+}
+
+/*
+Tells "handling of this packet blew up" (recoverable, keep reading) apart from "the transport is gone"
+(terminal, stop reading). Only a closed channel or a shut down executor mean that no further packet can
+ever arrive. Note that a cancelled receive is deliberately not terminal: some transports cancel the
+pending receive to signal a plain read timeout.
+ */
+private fun Throwable.isTransportGone(): Boolean = when (this) {
+    is ClosedChannelException, // also covers AsynchronousCloseException and ClosedByInterruptException
+    is ClosedSelectorException,
+    is RejectedExecutionException -> true
+
+    else -> false
+}
+
 fun <P, T : Transport<P>> T.listen(handler: Consumer<P>, executor: Executor = Executor(Runnable::run)): T {
     val logger = LoggerFactory.getLogger(javaClass)
 
     fun handle(packet: P?, err: Throwable?) {
         if (err != null) {
-            logger.warn("Listener stopped: {}", err.message, err)
-            return
-        }
-
-        if (packet != null) {
+            val cause = err.unwrapCompletion()
+            if (cause.isTransportGone()) {
+                logger.info("Listener stopped: {}", cause.toString())
+                return
+            }
+            // transport is still alive, only this packet blew up: log and keep reading
+            logger.error("Listener failed to receive: {}", cause.toString(), cause)
+        } else if (packet != null) {
             try {
                 handler.accept(packet)
             } catch (ex: Exception) {
                 logger.error(ex.toString(), ex)
             }
         }
+
         // continue
-        receive(Duration.ofSeconds(5)).whenCompleteAsync(::handle, executor)
+        try {
+            receive(Duration.ofSeconds(5)).whenCompleteAsync(::handle, executor)
+        } catch (ex: Exception) {
+            // transport got closed underneath us, there is nothing left to read from
+            logger.info("Listener stopped: {}", ex.toString())
+        }
     }
 
     // start loop

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,15 @@ import org.opencoap.ssl.util.millis
 import org.opencoap.ssl.util.seconds
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
+import java.nio.channels.ClosedChannelException
 import java.nio.channels.DatagramChannel
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import kotlin.random.Random
 
@@ -495,6 +498,119 @@ class DtlsServerTransportTest {
         }
 
         client.close()
+    }
+
+    @Test
+    fun `should keep listening after receive fails`() {
+        // given, packet handling blows up for a specific payload
+        server = DtlsServerTransport.create(conf)
+        server.failReceive { it == "poison" }.listen(echoHandler)
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+
+        // when
+        client.send("poison")
+
+        // then the listener kept reading
+        client.send("perse")
+        assertEquals("perse:resp", client.receiveString())
+
+        // and a brand new client can still handshake and echo
+        val client2 = DtlsTransmitter.connect(server, clientConfig).await()
+        client2.send("hi")
+        assertEquals("hi:resp", client2.receiveString())
+
+        client.close()
+        client2.close()
+    }
+
+    @Test
+    fun `should not accumulate pending receives when receive keeps failing`() {
+        // given
+        val poisonCount = 1000
+        val maxInFlight = AtomicInteger(0)
+        server = DtlsServerTransport.create(conf)
+        server.failReceive { it == "poison" }.trackInFlight(maxInFlight).listen(echoHandler)
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+
+        // when
+        repeat(poisonCount) { client.send("poison") }
+
+        // then still serving traffic, datagrams may have been dropped by the socket so keep retrying
+        await.atMost(30.seconds).untilAsserted {
+            client.send("perse")
+            assertEquals("perse:resp", client.receive(500.millis).await().decodeToString())
+        }
+
+        // and the loop keeps exactly one receive outstanding, no matter how many of them failed
+        assertEquals(1, maxInFlight.get())
+
+        // and scheduled tasks stay bounded by packets received, not by failures. They do not reach zero: every
+        // decrypted packet makes DtlsSession reschedule its expiry task and the cancelled one lingers in the
+        // queue, which happens for good packets just the same.
+        assertTrue((server.executor() as ScheduledThreadPoolExecutor).queue.size <= poisonCount + 100)
+
+        client.close()
+    }
+
+    @Test
+    fun `should stop listening when transport is gone`() {
+        // given, a transport that stays submittable but fails every receive once closed
+        val receiveCount = AtomicInteger(0)
+        val gone = AtomicBoolean(false)
+        val underlying = DatagramChannelAdapter.open(0)
+        val transport = object : Transport<ByteBufferPacket> by underlying {
+            override fun receive(timeout: Duration): CompletableFuture<ByteBufferPacket> {
+                receiveCount.incrementAndGet()
+                if (!gone.get()) return underlying.receive(timeout)
+                return CompletableFuture<ByteBufferPacket>().also { it.completeExceptionally(ClosedChannelException()) }
+            }
+        }
+        server = DtlsServerTransport.create(conf, transport = transport).listen(echoHandler)
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+        client.send("hi")
+        assertEquals("hi:resp", client.receiveString())
+
+        // when
+        gone.set(true)
+        client.send("hi") // completes the pending receive, so that the loop reschedules and hits the closed transport
+        Thread.sleep(500)
+
+        // then the loop terminated, it is not spinning on failed receives
+        val stoppedAt = receiveCount.get()
+        Thread.sleep(500)
+        assertEquals(stoppedAt, receiveCount.get())
+
+        client.close()
+    }
+
+    // records the highest number of receives that were outstanding at the same time
+    private fun <T> Transport<T>.trackInFlight(max: AtomicInteger): Transport<T> {
+        val underlying = this
+        val inFlight = AtomicInteger(0)
+
+        return object : Transport<T> by this {
+            override fun receive(timeout: Duration): CompletableFuture<T> {
+                val current = inFlight.incrementAndGet()
+                max.accumulateAndGet(current) { a, b -> maxOf(a, b) }
+                return underlying.receive(timeout).whenComplete { _, _ -> inFlight.decrementAndGet() }
+            }
+        }
+    }
+
+    // fails packet handling for every packet matching [poison], as an unexpected exception in the receive path would
+    private fun DtlsServerTransport.failReceive(poison: (String) -> Boolean): Transport<ByteBufferPacket> {
+        val underlying = this
+
+        return object : Transport<ByteBufferPacket> by this {
+            override fun receive(timeout: Duration): CompletableFuture<ByteBufferPacket> = underlying.receive(timeout)
+                .thenCompose { packet ->
+                    if (poison(packet.buffer.duplicate().decodeToString())) {
+                        CompletableFuture<ByteBufferPacket>().also { it.completeExceptionally(IllegalStateException("packet handling blew up")) }
+                    } else {
+                        completedFuture(packet)
+                    }
+                }
+        }
     }
 
     private fun <T> Transport<T>.dropReceive(drop: (Int) -> Boolean): Transport<T> {


### PR DESCRIPTION
When the future `listen()` awaits completed exceptionally, `handle` logged a warning and returned without scheduling another receive. The loop ended, the socket was never read again while the port stayed bound, and every subsequent datagram was silently discarded behind a single WARN line.

The loop now tells "handling of this packet blew up" apart from "the transport is gone": a closed channel, a closed selector or a shut down executor still terminate it, anything else is logged and the next receive is rescheduled, as on the success path. Rescheduling is also guarded, because a receive submitted to an executor that shut down underneath us throws synchronously - which up to now killed the loop with no log line at all.

A cancelled receive is deliberately not treated as terminal, because NettyTransportAdapter cancels the pending receive to signal a plain read timeout. That adapter also reported a closed channel as a bare IOException, which no caller can tell apart from a transient one, so it now reports ClosedChannelException - still an IOException, only specific enough to act on.

Not addressed here: scheduled tasks accumulate one dead entry per decrypted packet, because DtlsSession reschedules its expiry task on every packet and ScheduledThreadPoolExecutor keeps cancelled tasks queued. That is independent of this path - 1000 good packets accumulate exactly as many as 1000 failing ones - and is left for its own change.