### PR TITLE
fix(transport): bound-check DTLS record header parse in DtlsServer

### DIFF
--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -369,6 +369,12 @@ class DtlsServer(
     }
 
     private fun isValidHandshakeRequest(buf: ByteBuffer): Boolean {
+        // The fixed-offset reads require 14 bytes; a valid ClientHello requires at least 67.
+        if (buf.remaining() < 14) {
+            logger.debug("Datagram too short for a DTLS handshake header")
+            return false
+        }
+
         val workingBuf = buf.slice().order(ByteOrder.BIG_ENDIAN)
 
         // Check if the header is correct:

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.opencoap.ssl.transport
 
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.mockk.verify
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -37,6 +40,7 @@ import org.opencoap.ssl.util.decodeHex
 import org.opencoap.ssl.util.flip0
 import org.opencoap.ssl.util.localAddress
 import org.opencoap.ssl.util.millis
+import org.opencoap.ssl.util.truncatedDtlsHandshakeHeader
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.time.Instant
@@ -53,12 +57,13 @@ class DtlsServerTest {
     val serverConfInvalidCid = SslConfig.server(CertificateAuth(Certs.serverChain, Certs.server.privateKey), listOf("TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256"), false, InvalidCidSupplier(16))
 
     private val sessionStore = HashMapSessionStore()
+    private val lifecycleCallbacks: DtlsSessionLifecycleCallbacks = mockk(relaxed = true)
     private lateinit var dtlsServer: DtlsServer
     private val serverOutboundQueue = LinkedList<ByteBuffer>()
 
     @BeforeEach
     fun setUp() {
-        dtlsServer = DtlsServer(::outboundTransport, serverConf, 100.millis, sessionStore::write, executor = SingleThreadExecutor.create("dtls-srv-"))
+        dtlsServer = DtlsServer(::outboundTransport, serverConf, 100.millis, sessionStore::write, lifecycleCallbacks, executor = SingleThreadExecutor.create("dtls-srv-"))
     }
 
     private fun outboundTransport(it: ByteBufferPacket): CompletableFuture<Boolean> {
@@ -69,6 +74,7 @@ class DtlsServerTest {
     @AfterEach
     fun tearDown() {
         dtlsServer.closeSessions()
+        clearMocks(lifecycleCallbacks)
     }
 
     @AfterAll
@@ -303,6 +309,36 @@ class DtlsServerTest {
         assertEquals(256, buf.position())
         buf.readShortAndSeek()
         assertEquals(65793, buf.position())
+    }
+
+    // isValidHandshakeRequest reads 8 bytes at offset 0 and one byte at offset 13. Before the
+    // bound check, every length below 14 threw out of handleReceived() rather than being
+    // rejected: 0-7 failed the 8-byte read, 8-13 passed the header check and then failed the
+    // handshake-type read.
+    @Test
+    fun `should drop datagrams shorter than the handshake header`() {
+        val adr = localAddress(2_5684)
+
+        for (len in 0..13) {
+            val result = dtlsServer.handleReceived(adr, ByteBuffer.wrap(truncatedDtlsHandshakeHeader.copyOf(len)))
+            assertTrue(result is ReceiveResult.Handled, "expected Handled for length $len, got $result")
+        }
+
+        assertEquals(0, dtlsServer.numberOfSessions)
+        verify(exactly = 14) { lifecycleCallbacks.messageDropped(adr) }
+    }
+
+    @Test
+    fun `should not throw for randomised datagrams`() {
+        val random = Random(1)
+        val adr = localAddress(2_5684)
+
+        repeat(20_000) {
+            dtlsServer.handleReceived(adr, ByteBuffer.wrap(random.nextBytes(random.nextInt(0, 301))))
+        }
+
+        // nothing random passed as a handshake, so the parse path stayed a pure filter
+        assertEquals(0, dtlsServer.numberOfSessions)
     }
 
     private fun clientHandshake(): SslSession {

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -40,6 +40,7 @@ import org.opencoap.ssl.util.localAddress
 import org.opencoap.ssl.util.mapToString
 import org.opencoap.ssl.util.millis
 import org.opencoap.ssl.util.seconds
+import org.opencoap.ssl.util.truncatedDtlsHandshakeHeader
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.channels.ClosedChannelException
@@ -246,6 +247,29 @@ class DtlsServerTransportTest {
         verify(exactly = 0) {
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, ofType(HelloVerifyRequired::class))
         }
+    }
+
+    // Any datagram shorter than the 14 bytes that isValidHandshakeRequest reads used to throw
+    // out of DtlsServer.handleReceived(), which reached Transport.listen()'s `handle` callback
+    // as `err != null` and ended the receive loop for good. After the fix the server must drop
+    // every one of them and keep serving legitimate clients.
+    @Test
+    fun `should survive short malformed datagrams and keep serving`() {
+        server = DtlsServerTransport.create(conf, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        val cliChannel = DatagramChannel.open().connect(server.localAddress())
+        try {
+            for (len in 0..13) {
+                cliChannel.write(ByteBuffer.wrap(truncatedDtlsHandshakeHeader.copyOf(len)))
+            }
+        } finally {
+            cliChannel.close()
+        }
+
+        // server is still alive: a legitimate client can still handshake and exchange data
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+        client.send("ok-after-junk")
+        assertEquals("ok-after-junk:resp", client.receiveString())
+        client.close()
     }
 
     @Test

--- a/kotlin-mbedtls/src/testFixtures/kotlin/org/opencoap/ssl/util/Utils.kt
+++ b/kotlin-mbedtls/src/testFixtures/kotlin/org/opencoap/ssl/util/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,3 +64,6 @@ fun ByteBuffer.flip0(): ByteBuffer {
     this.flip()
     return this
 }
+
+// Lengths 0-7 truncate the DTLS header; 8-13 omit the handshake type at offset 13.
+val truncatedDtlsHandshakeHeader = "16FEFD00000000000000000000".decodeHex()


### PR DESCRIPTION
Reject DTLS datagrams shorter than the 14-byte header required by isValidHandshakeRequest.
Previously, malformed short packets could throw IndexOutOfBoundsException and terminate the server receive loop.