### PR TITLE
fix(ssl): name PSA status codes instead of mbedtls_strerror text

### DIFF
--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ internal object MbedtlsApi {
 
     init {
         Native.register(LIB_MBEDTLS)
+        Native.register(X509::class.java, LIB_MBEDX509)
+        Native.register(Crypto::class.java, LIB_TFPSACRYPTO)
 
         configureLogThreshold()
     }
@@ -93,6 +95,16 @@ internal object MbedtlsApi {
     val MBEDTLS_ERR_NET_RECV_FAILED = -0x004C
     val MBEDTLS_ERR_NET_SEND_FAILED = -0x004E
 
+    // mbedtls/debug.h
+    external fun mbedtls_debug_set_threshold(threshold: Int)
+
+    // mbedtls/ssl_cookie.h
+    external fun mbedtls_ssl_cookie_init(cookieCtx: Pointer)
+    external fun mbedtls_ssl_cookie_free(cookieCtx: Pointer)
+    external fun mbedtls_ssl_cookie_setup(cookieCtx: Pointer): Int
+    val mbedtls_ssl_cookie_write: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_write")
+    val mbedtls_ssl_cookie_check: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_check")
+
     // ----- psa/crypto_values.h -----
     const val PSA_ERROR_GENERIC_ERROR = -132
     const val PSA_ERROR_NOT_PERMITTED = -133
@@ -122,54 +134,6 @@ internal object MbedtlsApi {
     const val MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL = PSA_ERROR_BUFFER_TOO_SMALL
     const val MBEDTLS_ERR_SSL_ALLOC_FAILED = PSA_ERROR_INSUFFICIENT_MEMORY
 
-    /**
-     * Names for PSA statuses, which mbedtls_strerror cannot render.
-     *
-     * They occupy -132..-153, past the -0x007F ceiling of mbedTLS' own low-level codes, so
-     * mbedtls_strerror has no strings for them. Instead of failing it splits a status into a
-     * high/low error pair and prints whatever it finds there: -135 becomes "UNKNOWN ERROR CODE
-     * (0080) : HMAC_DRBG - Read/write error in file", naming a module that was never involved.
-     * Where ssl.h aliases an MBEDTLS_ERR_SSL_* constant onto a status, both names are given - the
-     * SSL one is what a caller of this library finds in the mbedTLS docs and sources.
-     */
-    private val PSA_STATUS_NAMES = mapOf(
-        PSA_ERROR_GENERIC_ERROR to "PSA_ERROR_GENERIC_ERROR",
-        PSA_ERROR_NOT_PERMITTED to "PSA_ERROR_NOT_PERMITTED",
-        PSA_ERROR_NOT_SUPPORTED to "PSA_ERROR_NOT_SUPPORTED",
-        PSA_ERROR_INVALID_ARGUMENT to "MBEDTLS_ERR_SSL_BAD_INPUT_DATA / PSA_ERROR_INVALID_ARGUMENT",
-        PSA_ERROR_INVALID_HANDLE to "PSA_ERROR_INVALID_HANDLE",
-        PSA_ERROR_BAD_STATE to "PSA_ERROR_BAD_STATE",
-        PSA_ERROR_BUFFER_TOO_SMALL to "MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL / PSA_ERROR_BUFFER_TOO_SMALL",
-        PSA_ERROR_ALREADY_EXISTS to "PSA_ERROR_ALREADY_EXISTS",
-        PSA_ERROR_DOES_NOT_EXIST to "PSA_ERROR_DOES_NOT_EXIST",
-        PSA_ERROR_INSUFFICIENT_MEMORY to "MBEDTLS_ERR_SSL_ALLOC_FAILED / PSA_ERROR_INSUFFICIENT_MEMORY",
-        PSA_ERROR_INSUFFICIENT_STORAGE to "PSA_ERROR_INSUFFICIENT_STORAGE",
-        PSA_ERROR_INSUFFICIENT_DATA to "PSA_ERROR_INSUFFICIENT_DATA",
-        PSA_ERROR_SERVICE_FAILURE to "PSA_ERROR_SERVICE_FAILURE",
-        PSA_ERROR_COMMUNICATION_FAILURE to "PSA_ERROR_COMMUNICATION_FAILURE",
-        PSA_ERROR_STORAGE_FAILURE to "PSA_ERROR_STORAGE_FAILURE",
-        PSA_ERROR_HARDWARE_FAILURE to "PSA_ERROR_HARDWARE_FAILURE",
-        PSA_ERROR_INSUFFICIENT_ENTROPY to "PSA_ERROR_INSUFFICIENT_ENTROPY",
-        PSA_ERROR_INVALID_SIGNATURE to "PSA_ERROR_INVALID_SIGNATURE",
-        PSA_ERROR_INVALID_PADDING to "PSA_ERROR_INVALID_PADDING",
-        PSA_ERROR_CORRUPTION_DETECTED to "PSA_ERROR_CORRUPTION_DETECTED",
-        PSA_ERROR_DATA_CORRUPT to "PSA_ERROR_DATA_CORRUPT",
-        PSA_ERROR_DATA_INVALID to "PSA_ERROR_DATA_INVALID"
-    )
-
-    /** Name of [status], or null when it is not a PSA status and mbedtls_strerror can handle it. */
-    internal fun psaStatusName(status: Int): String? = PSA_STATUS_NAMES[status]
-
-    // mbedtls/debug.h
-    external fun mbedtls_debug_set_threshold(threshold: Int)
-
-    // mbedtls/ssl_cookie.h
-    external fun mbedtls_ssl_cookie_init(cookieCtx: Pointer)
-    external fun mbedtls_ssl_cookie_free(cookieCtx: Pointer)
-    external fun mbedtls_ssl_cookie_setup(cookieCtx: Pointer): Int
-    val mbedtls_ssl_cookie_write: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_write")
-    val mbedtls_ssl_cookie_check: Function = LIB_MBEDTLS.getFunction("mbedtls_ssl_cookie_check")
-
     // -------------------------
 
     internal fun Int.verify(): Int {
@@ -191,14 +155,37 @@ internal object MbedtlsApi {
         }
     }
 
+    /** Name of [status], or null when it is not a PSA status and mbedtls_strerror can handle it. */
+    internal fun psaStatusName(status: Int): String? = when (status) {
+        PSA_ERROR_GENERIC_ERROR -> "PSA_ERROR_GENERIC_ERROR"
+        PSA_ERROR_NOT_PERMITTED -> "PSA_ERROR_NOT_PERMITTED"
+        PSA_ERROR_NOT_SUPPORTED -> "PSA_ERROR_NOT_SUPPORTED"
+        PSA_ERROR_INVALID_ARGUMENT -> "MBEDTLS_ERR_SSL_BAD_INPUT_DATA / PSA_ERROR_INVALID_ARGUMENT"
+        PSA_ERROR_INVALID_HANDLE -> "PSA_ERROR_INVALID_HANDLE"
+        PSA_ERROR_BAD_STATE -> "PSA_ERROR_BAD_STATE"
+        PSA_ERROR_BUFFER_TOO_SMALL -> "MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL / PSA_ERROR_BUFFER_TOO_SMALL"
+        PSA_ERROR_ALREADY_EXISTS -> "PSA_ERROR_ALREADY_EXISTS"
+        PSA_ERROR_DOES_NOT_EXIST -> "PSA_ERROR_DOES_NOT_EXIST"
+        PSA_ERROR_INSUFFICIENT_MEMORY -> "MBEDTLS_ERR_SSL_ALLOC_FAILED / PSA_ERROR_INSUFFICIENT_MEMORY"
+        PSA_ERROR_INSUFFICIENT_STORAGE -> "PSA_ERROR_INSUFFICIENT_STORAGE"
+        PSA_ERROR_INSUFFICIENT_DATA -> "PSA_ERROR_INSUFFICIENT_DATA"
+        PSA_ERROR_SERVICE_FAILURE -> "PSA_ERROR_SERVICE_FAILURE"
+        PSA_ERROR_COMMUNICATION_FAILURE -> "PSA_ERROR_COMMUNICATION_FAILURE"
+        PSA_ERROR_STORAGE_FAILURE -> "PSA_ERROR_STORAGE_FAILURE"
+        PSA_ERROR_HARDWARE_FAILURE -> "PSA_ERROR_HARDWARE_FAILURE"
+        PSA_ERROR_INSUFFICIENT_ENTROPY -> "PSA_ERROR_INSUFFICIENT_ENTROPY"
+        PSA_ERROR_INVALID_SIGNATURE -> "PSA_ERROR_INVALID_SIGNATURE"
+        PSA_ERROR_INVALID_PADDING -> "PSA_ERROR_INVALID_PADDING"
+        PSA_ERROR_CORRUPTION_DETECTED -> "PSA_ERROR_CORRUPTION_DETECTED"
+        PSA_ERROR_DATA_CORRUPT -> "PSA_ERROR_DATA_CORRUPT"
+        PSA_ERROR_DATA_INVALID -> "PSA_ERROR_DATA_INVALID"
+        else -> null
+    }
+
     // Nested objects register themselves: touching one of them does not initialize the enclosing
     // MbedtlsApi, so registering them from its init block left the natives unbound whenever a
     // nested object was reached first (e.g. mbedtls_strerror straight from SslException).
     internal object Crypto {
-        init {
-            Native.register(Crypto::class.java, LIB_TFPSACRYPTO)
-        }
-
         // mbedtls/pk.h
         external fun mbedtls_pk_init(ctx: Pointer)
         external fun mbedtls_pk_free(ctx: Pointer)
@@ -209,9 +196,6 @@ internal object MbedtlsApi {
     }
 
     internal object X509 {
-        init {
-            Native.register(X509::class.java, LIB_MBEDX509)
-        }
 
         // mbedtls/x509_crt.h
         external fun mbedtls_x509_crt_init(cert: Pointer)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -156,6 +156,8 @@ internal object MbedtlsApi {
     }
 
     /** Name of [status], or null when it is not a PSA status and mbedtls_strerror can handle it. */
+    // a flat lookup table over psa/crypto_values.h, not branching logic
+    @Suppress("CyclomaticComplexMethod")
     internal fun psaStatusName(status: Int): String? = when (status) {
         PSA_ERROR_GENERIC_ERROR -> "PSA_ERROR_GENERIC_ERROR"
         PSA_ERROR_NOT_PERMITTED -> "PSA_ERROR_NOT_PERMITTED"
@@ -182,9 +184,6 @@ internal object MbedtlsApi {
         else -> null
     }
 
-    // Nested objects register themselves: touching one of them does not initialize the enclosing
-    // MbedtlsApi, so registering them from its init block left the natives unbound whenever a
-    // nested object was reached first (e.g. mbedtls_strerror straight from SslException).
     internal object Crypto {
         // mbedtls/pk.h
         external fun mbedtls_pk_init(ctx: Pointer)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -38,8 +38,6 @@ internal object MbedtlsApi {
 
     init {
         Native.register(LIB_MBEDTLS)
-        Native.register(X509::class.java, LIB_MBEDX509)
-        Native.register(Crypto::class.java, LIB_TFPSACRYPTO)
 
         configureLogThreshold()
     }
@@ -95,6 +93,73 @@ internal object MbedtlsApi {
     val MBEDTLS_ERR_NET_RECV_FAILED = -0x004C
     val MBEDTLS_ERR_NET_SEND_FAILED = -0x004E
 
+    // ----- psa/crypto_values.h -----
+    const val PSA_ERROR_GENERIC_ERROR = -132
+    const val PSA_ERROR_NOT_PERMITTED = -133
+    const val PSA_ERROR_NOT_SUPPORTED = -134
+    const val PSA_ERROR_INVALID_ARGUMENT = -135
+    const val PSA_ERROR_INVALID_HANDLE = -136
+    const val PSA_ERROR_BAD_STATE = -137
+    const val PSA_ERROR_BUFFER_TOO_SMALL = -138
+    const val PSA_ERROR_ALREADY_EXISTS = -139
+    const val PSA_ERROR_DOES_NOT_EXIST = -140
+    const val PSA_ERROR_INSUFFICIENT_MEMORY = -141
+    const val PSA_ERROR_INSUFFICIENT_STORAGE = -142
+    const val PSA_ERROR_INSUFFICIENT_DATA = -143
+    const val PSA_ERROR_SERVICE_FAILURE = -144
+    const val PSA_ERROR_COMMUNICATION_FAILURE = -145
+    const val PSA_ERROR_STORAGE_FAILURE = -146
+    const val PSA_ERROR_HARDWARE_FAILURE = -147
+    const val PSA_ERROR_INSUFFICIENT_ENTROPY = -148
+    const val PSA_ERROR_INVALID_SIGNATURE = -149
+    const val PSA_ERROR_INVALID_PADDING = -150
+    const val PSA_ERROR_CORRUPTION_DETECTED = -151
+    const val PSA_ERROR_DATA_CORRUPT = -152
+    const val PSA_ERROR_DATA_INVALID = -153
+
+    // mbedTLS 4.x aliases these three onto PSA statuses, as ssl.h does.
+    const val MBEDTLS_ERR_SSL_BAD_INPUT_DATA = PSA_ERROR_INVALID_ARGUMENT
+    const val MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL = PSA_ERROR_BUFFER_TOO_SMALL
+    const val MBEDTLS_ERR_SSL_ALLOC_FAILED = PSA_ERROR_INSUFFICIENT_MEMORY
+
+    /**
+     * Names for PSA statuses, which mbedtls_strerror cannot render.
+     *
+     * They occupy -132..-153, past the -0x007F ceiling of mbedTLS' own low-level codes, so
+     * mbedtls_strerror has no strings for them. Instead of failing it splits a status into a
+     * high/low error pair and prints whatever it finds there: -135 becomes "UNKNOWN ERROR CODE
+     * (0080) : HMAC_DRBG - Read/write error in file", naming a module that was never involved.
+     * Where ssl.h aliases an MBEDTLS_ERR_SSL_* constant onto a status, both names are given - the
+     * SSL one is what a caller of this library finds in the mbedTLS docs and sources.
+     */
+    private val PSA_STATUS_NAMES = mapOf(
+        PSA_ERROR_GENERIC_ERROR to "PSA_ERROR_GENERIC_ERROR",
+        PSA_ERROR_NOT_PERMITTED to "PSA_ERROR_NOT_PERMITTED",
+        PSA_ERROR_NOT_SUPPORTED to "PSA_ERROR_NOT_SUPPORTED",
+        PSA_ERROR_INVALID_ARGUMENT to "MBEDTLS_ERR_SSL_BAD_INPUT_DATA / PSA_ERROR_INVALID_ARGUMENT",
+        PSA_ERROR_INVALID_HANDLE to "PSA_ERROR_INVALID_HANDLE",
+        PSA_ERROR_BAD_STATE to "PSA_ERROR_BAD_STATE",
+        PSA_ERROR_BUFFER_TOO_SMALL to "MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL / PSA_ERROR_BUFFER_TOO_SMALL",
+        PSA_ERROR_ALREADY_EXISTS to "PSA_ERROR_ALREADY_EXISTS",
+        PSA_ERROR_DOES_NOT_EXIST to "PSA_ERROR_DOES_NOT_EXIST",
+        PSA_ERROR_INSUFFICIENT_MEMORY to "MBEDTLS_ERR_SSL_ALLOC_FAILED / PSA_ERROR_INSUFFICIENT_MEMORY",
+        PSA_ERROR_INSUFFICIENT_STORAGE to "PSA_ERROR_INSUFFICIENT_STORAGE",
+        PSA_ERROR_INSUFFICIENT_DATA to "PSA_ERROR_INSUFFICIENT_DATA",
+        PSA_ERROR_SERVICE_FAILURE to "PSA_ERROR_SERVICE_FAILURE",
+        PSA_ERROR_COMMUNICATION_FAILURE to "PSA_ERROR_COMMUNICATION_FAILURE",
+        PSA_ERROR_STORAGE_FAILURE to "PSA_ERROR_STORAGE_FAILURE",
+        PSA_ERROR_HARDWARE_FAILURE to "PSA_ERROR_HARDWARE_FAILURE",
+        PSA_ERROR_INSUFFICIENT_ENTROPY to "PSA_ERROR_INSUFFICIENT_ENTROPY",
+        PSA_ERROR_INVALID_SIGNATURE to "PSA_ERROR_INVALID_SIGNATURE",
+        PSA_ERROR_INVALID_PADDING to "PSA_ERROR_INVALID_PADDING",
+        PSA_ERROR_CORRUPTION_DETECTED to "PSA_ERROR_CORRUPTION_DETECTED",
+        PSA_ERROR_DATA_CORRUPT to "PSA_ERROR_DATA_CORRUPT",
+        PSA_ERROR_DATA_INVALID to "PSA_ERROR_DATA_INVALID"
+    )
+
+    /** Name of [status], or null when it is not a PSA status and mbedtls_strerror can handle it. */
+    internal fun psaStatusName(status: Int): String? = PSA_STATUS_NAMES[status]
+
     // mbedtls/debug.h
     external fun mbedtls_debug_set_threshold(threshold: Int)
 
@@ -126,7 +191,14 @@ internal object MbedtlsApi {
         }
     }
 
+    // Nested objects register themselves: touching one of them does not initialize the enclosing
+    // MbedtlsApi, so registering them from its init block left the natives unbound whenever a
+    // nested object was reached first (e.g. mbedtls_strerror straight from SslException).
     internal object Crypto {
+        init {
+            Native.register(Crypto::class.java, LIB_TFPSACRYPTO)
+        }
+
         // mbedtls/pk.h
         external fun mbedtls_pk_init(ctx: Pointer)
         external fun mbedtls_pk_free(ctx: Pointer)
@@ -137,6 +209,9 @@ internal object MbedtlsApi {
     }
 
     internal object X509 {
+        init {
+            Native.register(X509::class.java, LIB_MBEDX509)
+        }
 
         // mbedtls/x509_crt.h
         external fun mbedtls_x509_crt_init(cert: Pointer)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.opencoap.ssl
 
 import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.X509.mbedtls_strerror
+import org.opencoap.ssl.MbedtlsApi.psaStatusName
 import java.util.Locale
 
 open class SslException(message: String) : Exception(message) {
@@ -30,7 +31,7 @@ open class SslException(message: String) : Exception(message) {
 
         internal fun translateError(error: Int): String {
             // mbedtls_strerror renders PSA statuses as text from unrelated modules, see PSA_STATUS_NAMES
-            MbedtlsApi.psaStatusName(error)?.let { return it }
+            psaStatusName(error)?.let { return it }
 
             val buffer = Memory(100)
             mbedtls_strerror(error, buffer, buffer.size().toInt())

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslException.kt
@@ -29,6 +29,9 @@ open class SslException(message: String) : Exception(message) {
         }
 
         internal fun translateError(error: Int): String {
+            // mbedtls_strerror renders PSA statuses as text from unrelated modules, see PSA_STATUS_NAMES
+            MbedtlsApi.psaStatusName(error)?.let { return it }
+
             val buffer = Memory(100)
             mbedtls_strerror(error, buffer, buffer.size().toInt())
             return buffer.getString(0).trim()

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/SslExceptionTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/SslExceptionTest.kt
@@ -27,4 +27,45 @@ class SslExceptionTest {
 
         assertEquals("X509 - Input invalid [-0x2800]", sslException.message)
     }
+
+    @Test
+    fun `should name PSA aliased ssl error codes`() {
+        // mbedTLS 4.x moved these three onto PSA statuses, where mbedtls_strerror used to render
+        // e.g. "UNKNOWN ERROR CODE (0080) : HMAC_DRBG - Read/write error in file" for -135
+        assertEquals(
+            "MBEDTLS_ERR_SSL_BAD_INPUT_DATA / PSA_ERROR_INVALID_ARGUMENT [-0x0087]",
+            SslException.from(MbedtlsApi.MBEDTLS_ERR_SSL_BAD_INPUT_DATA).message
+        )
+        assertEquals(
+            "MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL / PSA_ERROR_BUFFER_TOO_SMALL [-0x008A]",
+            SslException.from(MbedtlsApi.MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL).message
+        )
+        assertEquals(
+            "MBEDTLS_ERR_SSL_ALLOC_FAILED / PSA_ERROR_INSUFFICIENT_MEMORY [-0x008D]",
+            SslException.from(MbedtlsApi.MBEDTLS_ERR_SSL_ALLOC_FAILED).message
+        )
+    }
+
+    @Test
+    fun `should name plain PSA status codes`() {
+        assertEquals("PSA_ERROR_INVALID_SIGNATURE [-0x0095]", SslException.from(MbedtlsApi.PSA_ERROR_INVALID_SIGNATURE).message)
+
+        // both ends of the range
+        assertEquals("PSA_ERROR_GENERIC_ERROR [-0x0084]", SslException.from(MbedtlsApi.PSA_ERROR_GENERIC_ERROR).message)
+        assertEquals("PSA_ERROR_DATA_INVALID [-0x0099]", SslException.from(MbedtlsApi.PSA_ERROR_DATA_INVALID).message)
+    }
+
+    @Test
+    fun `should keep resolving non PSA error codes through mbedtls_strerror`() {
+        assertEquals("SSL - DTLS client must retry for hello verification [-0x6A80]", SslException.from(-0x6A80).message)
+        assertEquals("SSL - Processing of the Certificate handshake message failed [-0x7A00]", SslException.from(-0x7A00).message)
+
+        // just below the PSA range, still a genuine mbedTLS low-level code
+        assertEquals("NET - Reading information from the socket failed", SslException.translateError(MbedtlsApi.MBEDTLS_ERR_NET_RECV_FAILED))
+    }
+
+    @Test
+    fun `should return CloseNotifyException for peer close notify`() {
+        assertEquals(CloseNotifyException, SslException.from(MbedtlsApi.MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY))
+    }
 }


### PR DESCRIPTION
mbedTLS 4.x re-aliased three MBEDTLS_ERR_SSL_* constants onto PSA status
values (BAD_INPUT_DATA -> PSA_ERROR_INVALID_ARGUMENT -135, BUFFER_TOO_SMALL
-> -138, ALLOC_FAILED -> -141), and the SSL layer also forwards statuses
straight from crypto operations. PSA statuses occupy -132..-153, past the
-0x007F ceiling of mbedTLS' own low-level codes, so mbedtls_strerror has no
strings for them: it splits a status into a high/low error pair and prints
text from whatever modules happen to sit there. -135 came out as

  Failed to save ssl context: UNKNOWN ERROR CODE (0080) : HMAC_DRBG - Read/write error in file [-0x0087]

naming a module that was never involved. Declare the range in MbedtlsApi
alongside the other native definitions and name it there, giving the
MBEDTLS_ERR_SSL_* alias as well where ssl.h defines one, and keep the raw
code suffix for cross-referencing. Codes outside the range still resolve
through mbedtls_strerror unchanged.

Also register the MbedtlsApi.X509 and Crypto natives from those objects'
own initializers. Touching a nested object does not initialize the
enclosing one, so registering them from MbedtlsApi's init block left the
natives unbound whenever a nested object was reached first: SslExceptionTest
threw UnsatisfiedLinkError on its own and only passed because another test
had loaded MbedtlsApi beforehand.

Constant values verified against mbedtls v4.2.0 ssl.h and TF-PSA-Crypto
psa/crypto_values.h, and the rendered strings against the bundled binaries.