### PR TITLE
fix: stop leaking and double-reporting unsaveable sessions

### DIFF
--- a/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
+++ b/kotlin-mbedtls-metrics/src/test/kotlin/org/opencoap/ssl/transport/metrics/micrometer/DtlsServerMetricsCallbacksTest.kt
@@ -112,8 +112,26 @@ class DtlsServerMetricsCallbacksTest {
         assertEquals(2, meterRegistry.find("dtls.server.handshakes.initiated").counter()?.count()?.toInt())
         assertEquals(1, meterRegistry.find("dtls.server.handshakes.succeeded").timer()?.count()?.toInt())
         assertEquals(1, meterRegistry.find("dtls.server.sessions.started").tag("suite") { it.isNotEmpty() }.counter()?.count()?.toInt())
-        assertEquals(1, meterRegistry.find("dtls.server.sessions.expired").counter()?.count()?.toInt())
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.stored").counter()?.count()?.toInt())
+        assertEquals(0, meterRegistry.find("dtls.server.sessions.expired").counter()?.count()?.toInt())
         assertEquals(1, meterRegistry.find("dtls.server.sessions.reloaded").counter()?.count()?.toInt())
+    }
+
+    @Test
+    fun `should report DTLS server metrics for sessions that carried no application data`() {
+        server = DtlsServerTransport.create(conf, sessionStore = sessionStore, lifecycleCallbacks = metricsCallbacks, expireAfter = Duration.ofMillis(200)).listen(echoHandler)
+
+        // when, a session handshakes and stays silent until it idles out
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+        await.atMost(Duration.ofSeconds(1)).untilAsserted {
+            assertEquals(0, server.numberOfSessions())
+        }
+        client.close()
+
+        // then it counts as expired, leaving the failure count untouched
+        assertEquals(1, meterRegistry.find("dtls.server.sessions.expired").counter()?.count()?.toInt())
+        assertEquals(0, meterRegistry.find("dtls.server.sessions.stored").counter()?.count()?.toInt())
+        assertEquals(null, meterRegistry.find("dtls.server.sessions.failed").counter()?.count()?.toInt())
     }
 
     @Test

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,18 +199,13 @@ class SslSession internal constructor(
         }
     }
 
-    fun saveAndClose(): ByteArray {
+    fun saveAndClose(): ByteArray = use {
         val buffer = ByteArray(1280)
         val outputLen = ByteArray(4)
-        try {
-            mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
-        } finally {
-            // on failure the context is left unusable and nothing else frees it
-            close()
-        }
+        mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
 
         val size = (outputLen[0].toInt() and 0xff) + (outputLen[1].toInt() and 0xff shl 8)
-        return buffer.copyOf(size)
+        buffer.copyOf(size)
     }
 
     override fun toString(): String = when {

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -120,6 +120,10 @@ class SslSession internal constructor(
     val ownCid: ByteArray? = if (peerCid != null) cid else null
     val peerCertificateSubject: String? = readPeerCertificateSubject()
 
+    // mbedtls_ssl_free must run exactly once, a second call would free the same buffers twice
+    internal var isClosed: Boolean = false
+        private set
+
     private fun readPeerCid(): ByteArray? {
         val mem = Memory(16 + 64) // max cid len
         mbedtls_ssl_get_peer_cid(sslContext, mem, mem.share(16), mem.share(8))
@@ -198,8 +202,12 @@ class SslSession internal constructor(
     fun saveAndClose(): ByteArray {
         val buffer = ByteArray(1280)
         val outputLen = ByteArray(4)
-        mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
-        close()
+        try {
+            mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
+        } finally {
+            // on failure the context is left unusable and nothing else frees it
+            close()
+        }
 
         val size = (outputLen[0].toInt() and 0xff) + (outputLen[1].toInt() and 0xff shl 8)
         return buffer.copyOf(size)
@@ -224,6 +232,8 @@ class SslSession internal constructor(
     } ?: ByteBuffer.allocate(0)
 
     override fun close() {
+        if (isClosed) return
+        isClosed = true
         mbedtls_ssl_free(sslContext)
     }
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -121,15 +121,7 @@ class DtlsServer(
     }
 
     private fun closeSession(addr: InetSocketAddress) {
-        sessions.remove(addr)?.apply {
-            storeAndClose()
-            logger.info(
-                "[{}] [CID:{}] DTLS session was stored",
-                peerAddress,
-                (this as? DtlsSession)?.sessionContext?.cid?.toHex()
-                    ?: "na"
-            )
-        }
+        sessions.remove(addr)?.storeAndClose()
     }
 
     fun handleOutboundDtlsSessionContext(adr: InetSocketAddress, ctx: DtlsSessionContext, writeFuture: CompletableFuture<Boolean>) {
@@ -283,35 +275,49 @@ class DtlsServer(
                 sessionStartTimestamp = sessionStartTimestamp
             )
 
+        // mbedtls_ssl_context_save fails until mbedTLS drops the handshake structure, which it keeps
+        // for retransmission until the first inbound record. A restored session never had one.
+        private var storable: Boolean = ctx.reloaded
+
         init {
             scheduledTask = executor.schedule(::timeout, expireAfter)
             reportSessionStarted()
         }
 
         override fun storeAndClose0() {
-            if (ctx.ownCid != null) {
-                try {
-                    val sessionBlob = try {
-                        ctx.saveAndClose()
-                    } catch (ex: Exception) {
-                        logger.warn("[{}] [CID:{}] Failed to save ssl context: {}", peerAddress, ownCidHex, ex.message)
-                        return reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
-                    }
-                    val session = SessionWithContext(
-                        sessionBlob = sessionBlob,
-                        authenticationContext = authenticationContext,
-                        sessionStartTimestamp = sessionStartTimestamp
-                    )
-                    storeSession(ctx.ownCid, session)
-                    reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.STORED)
-                } catch (ex: Exception) {
-                    logger.error("[{}] [CID:{}] DTLS failed to store session: {}", peerAddress, ownCidHex, ex.message)
-                    reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
-                }
-            } else {
+            val ownCid = ctx.ownCid
+            if (ownCid == null) {
                 close()
-                reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.CLOSED)
+                return reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.CLOSED)
             }
+
+            if (!storable) {
+                close()
+                logger.info("[{}] [CID:{}] DTLS session not stored, no record received after handshake", peerAddress, ownCidHex)
+                return reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
+            }
+
+            val sessionBlob = try {
+                ctx.saveAndClose()
+            } catch (ex: Exception) {
+                logger.warn("[{}] [CID:{}] Failed to save ssl context: {}", peerAddress, ownCidHex, ex.message)
+                return reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
+            }
+
+            val session = SessionWithContext(
+                sessionBlob = sessionBlob,
+                authenticationContext = authenticationContext,
+                sessionStartTimestamp = sessionStartTimestamp
+            )
+            try {
+                storeSession(ownCid, session)
+            } catch (ex: Exception) {
+                logger.error("[{}] [CID:{}] DTLS failed to store session: {}", peerAddress, ownCidHex, ex.message)
+                return reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.FAILED, ex)
+            }
+
+            logger.info("[{}] [CID:{}] DTLS session was stored", peerAddress, ownCidHex)
+            reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.STORED)
         }
 
         override fun close() = ctx.close()
@@ -320,6 +326,7 @@ class DtlsServer(
             scheduledTask.cancel(false)
             try {
                 val plainBuf = ctx.decrypt(encPacket, ::send)
+                storable = true
                 scheduledTask = executor.schedule(::timeout, expireAfter)
                 return if (plainBuf.isNotEmpty()) {
                     ReceiveResult.Decrypted(Packet(plainBuf, peerAddress, sessionContext))
@@ -353,8 +360,6 @@ class DtlsServer(
         fun timeout() {
             sessions.remove(peerAddress, this)
             storeAndClose()
-            logger.info("[{}] [CID:{}] DTLS session stored after idle", peerAddress, ownCidHex)
-            reportSessionFinished(DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
 
         private val ownCidHex: String get() = ctx.ownCid?.toHex() ?: "na"

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -267,6 +267,10 @@ class DtlsServer(
         private val sessionStartTimestamp: Instant = Instant.now()
     ) : DtlsState(peerAddress) {
 
+        // mbedtls_ssl_context_save fails until mbedTLS drops the handshake structure, which it keeps
+        // for retransmission until the first inbound record. A restored session never had one.
+        private var storable: Boolean = ctx.reloaded
+
         val sessionContext: DtlsSessionContext
             get() = DtlsSessionContext(
                 peerCertificateSubject = ctx.peerCertificateSubject,
@@ -274,10 +278,6 @@ class DtlsServer(
                 cid = if (ctx.ownCid?.isEmpty() != true) ctx.ownCid else ctx.peerCid,
                 sessionStartTimestamp = sessionStartTimestamp
             )
-
-        // mbedtls_ssl_context_save fails until mbedTLS drops the handshake structure, which it keeps
-        // for retransmission until the first inbound record. A restored session never had one.
-        private var storable: Boolean = ctx.reloaded
 
         init {
             scheduledTask = executor.schedule(::timeout, expireAfter)

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/SslContextTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/SslContextTest.kt
@@ -18,7 +18,9 @@ package org.opencoap.ssl
 
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.opencoap.ssl.transport.asByteBuffer
@@ -84,6 +86,34 @@ class SslContextTest {
 
     @Test
     fun `should handshake with certificate`() {
+        handshakeServerSession().close()
+    }
+
+    @Test
+    fun `should close ssl context when save fails`() {
+        // given, a server session that has not read a record yet, so mbedTLS still holds its
+        // handshake structure and refuses to serialise the context
+        val serverSslSession = handshakeServerSession()
+        assertFalse(serverSslSession.isClosed)
+
+        // when
+        assertThrows(SslException::class.java) { serverSslSession.saveAndClose() }
+
+        // then, the native context is released regardless
+        assertTrue(serverSslSession.isClosed)
+    }
+
+    @Test
+    fun `should close ssl context only once`() {
+        val serverSslSession = handshakeServerSession()
+
+        serverSslSession.close()
+        serverSslSession.close()
+
+        assertTrue(serverSslSession.isClosed)
+    }
+
+    private fun handshakeServerSession(): SslSession {
         lateinit var sendingBuffer: ByteBuffer
         val send: (ByteBuffer) -> Unit = { sendingBuffer = it }
         var srvHandshake = serverConf.newContext(localAddress(1_5684))
@@ -104,7 +134,7 @@ class SslContextTest {
         }
 
         assertTrue(serverSslSession is SslSession)
-        serverSslSession.close()
+        return serverSslSession as SslSession
     }
 
     @Test

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTransportTest.kt
@@ -385,10 +385,36 @@ class DtlsServerTransportTest {
         }
         client.close()
 
-        verify {
+        verify(exactly = 1) {
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
+        }
+        verify(exactly = 0) {
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
+    }
+
+    @Test
+    fun `should not store session when peer sent no application data`() {
+        // given, mbedTLS holds on to the server handshake structure until the peer sends a record,
+        // and refuses to serialise a context that still has one
+        server = DtlsServerTransport.create(conf, expireAfter = 10.millis, sessionStore = sessionStore, lifecycleCallbacks = sslLifecycleCallbacks).listen(echoHandler)
+        val client = DtlsTransmitter.connect(server, clientConfig).await()
+
+        // when, the session idles out without ever carrying application data
+        await.atMost(1.seconds).untilAsserted {
+            assertEquals(0, server.numberOfSessions())
+        }
+        client.close()
+
+        // then, it is reported once, and not as a failure
+        verify(exactly = 1) {
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
+        }
+        verify(exactly = 0) {
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.FAILED, any())
+            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
+        }
+        assertEquals(0, sessionStore.size())
     }
 
     @Test
@@ -426,10 +452,8 @@ class DtlsServerTransportTest {
             sslLifecycleCallbacks.handshakeFinished(any(), any(), any(), DtlsSessionLifecycleCallbacks.Reason.SUCCEEDED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), false)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
-            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
             sslLifecycleCallbacks.sessionStarted(any(), any(), true)
             sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.STORED)
-            sslLifecycleCallbacks.sessionFinished(any(), DtlsSessionLifecycleCallbacks.Reason.EXPIRED)
         }
 
         // Check no more callbacks are called


### PR DESCRIPTION
A DTLS server session that handshakes and then goes silent can never be saved: mbedTLS holds the handshake structure until an inbound record proves the peer got the final flight, and mbedtls_ssl_context_save refuses to serialise a context that still has one. That's accepted — such a peer has nothing worth storing. Two bugs in the failure handling are not:

- Leak. saveAndClose threw before its close(), and storeAndClose0 returned from its catch without closing. Nothing else calls mbedtls_ssl_free, so every such session leaked its context and both record buffers.
- Double report. timeout called storeAndClose() — already reporting FAILED/STORED — then also logged "session stored after idle" and reported EXPIRED. One session, two mutually exclusive counters, and a log claiming a store that never happened.

Fixes:

- saveAndClose frees in a finally; close() is idempotent, so use{} can't double-free.
- DtlsSession tracks whether it read a record and skips the save it knows will fail — INFO log, reported as EXPIRED, which is what it is: a handshake mbedTLS never considered finished. Genuine save failures still log WARN and report FAILED.
- storeAndClose0 owns the single report and logs the outcome it got. timeout and closeSession lose their unconditional lines.

For reviewers: sessions.expired narrows in meaning. It used to fire for every session hitting the idle timer, tracking sessions.stored one for one and carrying no information of its own; now it counts only sessions that ended unstored. handshakes.expired is untouched.