### PR TITLE
fix: bind context-save output length as a native size_t

### DIFF
--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -69,7 +69,12 @@ internal object MbedtlsApi {
     external fun mbedtls_ssl_conf_cid(mbedtlsSslConfig: Pointer, len: Int, ignoreOtherCids: Int): Int
     external fun mbedtls_ssl_set_cid(sslContext: Pointer, enable: Int, ownCid: ByteArray, ownCidLen: Int): Int
     external fun mbedtls_ssl_get_peer_cid(sslContext: Pointer, enabled: Pointer, peerCid: Pointer, peerCidLen: Pointer): Int
-    external fun mbedtls_ssl_context_save(sslContext: Pointer, buf: ByteArray, bufLen: Int, outputLen: ByteArray): Int
+
+    // outputLen is a size_t* out-parameter, so it must point at Native.SIZE_T_SIZE bytes of native memory.
+    // bufLen, like every other length parameter here, is a size_t passed by value: jna widens Int to the
+    // native word, so those stay Int for consistency with the rest of this binding.
+    external fun mbedtls_ssl_context_save(sslContext: Pointer, buf: ByteArray, bufLen: Int, outputLen: Pointer): Int
+
     external fun mbedtls_ssl_context_load(sslContext: Pointer, buf: ByteArray, len: Int): Int
     external fun mbedtls_ssl_check_record(sslContext: Pointer, buf: Memory, bufLen: Int): Int
     external fun mbedtls_ssl_conf_ca_chain(sslConfig: Pointer, caChain: Pointer, caCrl: Pointer?)
@@ -141,6 +146,17 @@ internal object MbedtlsApi {
 
         throw SslException.from(this)
     }
+
+    // Reads a size_t that mbedtls wrote through a length out-parameter, at the platform's own
+    // width and byte order rather than assuming a little-endian 64-bit target.
+    internal fun Pointer.getSizeT(offset: Long): Long = when (val width = Native.SIZE_T_SIZE) {
+        8 -> getLong(offset)
+        4 -> getInt(offset).toLong() and 0xFFFFFFFFL
+        else -> throw IllegalStateException("Unsupported native size_t width: $width")
+    }
+
+    // Allocates native memory for a single size_t out-parameter.
+    internal fun allocateSizeT(): Memory = Memory(Native.SIZE_T_SIZE.toLong())
 
     private fun configureLogThreshold() {
         val logger = LoggerFactory.getLogger(javaClass)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -83,11 +83,6 @@ internal object MbedtlsApi {
     external fun mbedtls_ssl_get_peer_cert(sslContext: Pointer): Pointer?
     external fun mbedtls_ssl_set_hostname(sslContext: Pointer, hostname: String?): Int
 
-    // size_t on every platform this library ships native libraries for: linux-x86-64,
-    // linux-aarch64, darwin and win32-x86-64. Windows is LLP64, so its long is 4 bytes
-    // while size_t is still 8. Pointer.getLong reads it in native byte order.
-    const val SIZE_T_LEN = 8L
-
     const val MBEDTLS_ERR_SSL_TIMEOUT = -0x6800
     const val MBEDTLS_ERR_SSL_WANT_READ = -0x6900
     const val MBEDTLS_ERR_SSL_WANT_WRITE = -0x6880

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -70,7 +70,7 @@ internal object MbedtlsApi {
     external fun mbedtls_ssl_set_cid(sslContext: Pointer, enable: Int, ownCid: ByteArray, ownCidLen: Int): Int
     external fun mbedtls_ssl_get_peer_cid(sslContext: Pointer, enabled: Pointer, peerCid: Pointer, peerCidLen: Pointer): Int
 
-    // outputLen is a size_t* out-parameter, so it must point at Native.SIZE_T_SIZE bytes of native memory.
+    // outputLen is a size_t* out-parameter, so it must point at SIZE_T_LEN bytes of native memory.
     // bufLen, like every other length parameter here, is a size_t passed by value: jna widens Int to the
     // native word, so those stay Int for consistency with the rest of this binding.
     external fun mbedtls_ssl_context_save(sslContext: Pointer, buf: ByteArray, bufLen: Int, outputLen: Pointer): Int
@@ -82,6 +82,11 @@ internal object MbedtlsApi {
     external fun mbedtls_ssl_set_mtu(sslContext: Pointer, mtu: Int)
     external fun mbedtls_ssl_get_peer_cert(sslContext: Pointer): Pointer?
     external fun mbedtls_ssl_set_hostname(sslContext: Pointer, hostname: String?): Int
+
+    // size_t on every platform this library ships native libraries for: linux-x86-64,
+    // linux-aarch64, darwin and win32-x86-64. Windows is LLP64, so its long is 4 bytes
+    // while size_t is still 8. Pointer.getLong reads it in native byte order.
+    const val SIZE_T_LEN = 8L
 
     const val MBEDTLS_ERR_SSL_TIMEOUT = -0x6800
     const val MBEDTLS_ERR_SSL_WANT_READ = -0x6900
@@ -146,17 +151,6 @@ internal object MbedtlsApi {
 
         throw SslException.from(this)
     }
-
-    // Reads a size_t that mbedtls wrote through a length out-parameter, at the platform's own
-    // width and byte order rather than assuming a little-endian 64-bit target.
-    internal fun Pointer.getSizeT(offset: Long): Long = when (val width = Native.SIZE_T_SIZE) {
-        8 -> getLong(offset)
-        4 -> getInt(offset).toLong() and 0xFFFFFFFFL
-        else -> throw IllegalStateException("Unsupported native size_t width: $width")
-    }
-
-    // Allocates native memory for a single size_t out-parameter.
-    internal fun allocateSizeT(): Memory = Memory(Native.SIZE_T_SIZE.toLong())
 
     private fun configureLogThreshold() {
         val logger = LoggerFactory.getLogger(javaClass)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/MbedtlsApi.kt
@@ -69,12 +69,7 @@ internal object MbedtlsApi {
     external fun mbedtls_ssl_conf_cid(mbedtlsSslConfig: Pointer, len: Int, ignoreOtherCids: Int): Int
     external fun mbedtls_ssl_set_cid(sslContext: Pointer, enable: Int, ownCid: ByteArray, ownCidLen: Int): Int
     external fun mbedtls_ssl_get_peer_cid(sslContext: Pointer, enabled: Pointer, peerCid: Pointer, peerCidLen: Pointer): Int
-
-    // outputLen is a size_t* out-parameter, so it must point at SIZE_T_LEN bytes of native memory.
-    // bufLen, like every other length parameter here, is a size_t passed by value: jna widens Int to the
-    // native word, so those stay Int for consistency with the rest of this binding.
     external fun mbedtls_ssl_context_save(sslContext: Pointer, buf: ByteArray, bufLen: Int, outputLen: Pointer): Int
-
     external fun mbedtls_ssl_context_load(sslContext: Pointer, buf: ByteArray, len: Int): Int
     external fun mbedtls_ssl_check_record(sslContext: Pointer, buf: Memory, bufLen: Int): Int
     external fun mbedtls_ssl_conf_ca_chain(sslConfig: Pointer, caChain: Pointer, caCrl: Pointer?)

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/NativeTypes.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/NativeTypes.kt
@@ -18,16 +18,4 @@ package org.opencoap.ssl
 
 import com.sun.jna.Pointer
 
-/*
-Mapping for C types that jna has no direct equivalent for.
- */
-
-// size_t is 8 bytes on every platform this library ships native libraries for: linux-x86-64,
-// linux-aarch64, darwin and win32-x86-64. Windows is LLP64, so its long is 4 bytes while size_t
-// is still 8. NativeTypesTest guards this against a future 32-bit target.
-internal const val SIZE_T_LEN = 8L
-
-// Reads a size_t that mbedtls wrote through a length out-parameter. Pointer.getLong reads native
-// memory in native byte order, so there is no endianness to handle here. Narrowed to Int like
-// every other length in this binding: mbedtls only writes buffer sizes through these.
 internal fun Pointer.getSizeT(offset: Long = 0): Int = getLong(offset).toInt()

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/NativeTypes.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/NativeTypes.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl
+
+import com.sun.jna.Pointer
+
+/*
+Mapping for C types that jna has no direct equivalent for.
+ */
+
+// size_t is 8 bytes on every platform this library ships native libraries for: linux-x86-64,
+// linux-aarch64, darwin and win32-x86-64. Windows is LLP64, so its long is 4 bytes while size_t
+// is still 8. NativeTypesTest guards this against a future 32-bit target.
+internal const val SIZE_T_LEN = 8L
+
+// Reads a size_t that mbedtls wrote through a length out-parameter. Pointer.getLong reads native
+// memory in native byte order, so there is no endianness to handle here. Narrowed to Int like
+// every other length in this binding: mbedtls only writes buffer sizes through these.
+internal fun Pointer.getSizeT(offset: Long = 0): Int = getLong(offset).toInt()

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -17,6 +17,7 @@
 package org.opencoap.ssl
 
 import com.sun.jna.Memory
+import com.sun.jna.Native.SIZE_T_SIZE
 import org.opencoap.ssl.MbedtlsApi.MBEDTLS_ERR_SSL_UNEXPECTED_RECORD
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_close_notify
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_context_save
@@ -201,7 +202,7 @@ class SslSession internal constructor(
 
     fun saveAndClose(): ByteArray = use {
         val buffer = ByteArray(1280)
-        Memory(SIZE_T_LEN).use { outputLen ->
+        Memory(SIZE_T_SIZE.toLong()).use { outputLen ->
             mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
             buffer.copyOf(outputLen.getSizeT())
         }

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -18,8 +18,7 @@ package org.opencoap.ssl
 
 import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.MBEDTLS_ERR_SSL_UNEXPECTED_RECORD
-import org.opencoap.ssl.MbedtlsApi.allocateSizeT
-import org.opencoap.ssl.MbedtlsApi.getSizeT
+import org.opencoap.ssl.MbedtlsApi.SIZE_T_LEN
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_close_notify
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_context_save
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_free
@@ -133,7 +132,7 @@ class SslSession internal constructor(
         if (mem.getInt(0) == 0) {
             return null
         }
-        val size = mem.getSizeT(8).toInt()
+        val size = mem.getLong(8).toInt()
 
         return mem.getByteArray(16, size)
     }
@@ -203,9 +202,9 @@ class SslSession internal constructor(
 
     fun saveAndClose(): ByteArray = use {
         val buffer = ByteArray(1280)
-        allocateSizeT().use { outputLen ->
+        Memory(SIZE_T_LEN).use { outputLen ->
             mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
-            buffer.copyOf(outputLen.getSizeT(0).toInt())
+            buffer.copyOf(outputLen.getLong(0).toInt())
         }
     }
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -18,7 +18,6 @@ package org.opencoap.ssl
 
 import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.MBEDTLS_ERR_SSL_UNEXPECTED_RECORD
-import org.opencoap.ssl.MbedtlsApi.SIZE_T_LEN
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_close_notify
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_context_save
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_free
@@ -132,7 +131,7 @@ class SslSession internal constructor(
         if (mem.getInt(0) == 0) {
             return null
         }
-        val size = mem.getLong(8).toInt()
+        val size = mem.getSizeT(8)
 
         return mem.getByteArray(16, size)
     }
@@ -204,7 +203,7 @@ class SslSession internal constructor(
         val buffer = ByteArray(1280)
         Memory(SIZE_T_LEN).use { outputLen ->
             mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
-            buffer.copyOf(outputLen.getLong(0).toInt())
+            buffer.copyOf(outputLen.getSizeT())
         }
     }
 

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/SslContext.kt
@@ -18,6 +18,8 @@ package org.opencoap.ssl
 
 import com.sun.jna.Memory
 import org.opencoap.ssl.MbedtlsApi.MBEDTLS_ERR_SSL_UNEXPECTED_RECORD
+import org.opencoap.ssl.MbedtlsApi.allocateSizeT
+import org.opencoap.ssl.MbedtlsApi.getSizeT
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_close_notify
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_context_save
 import org.opencoap.ssl.MbedtlsApi.mbedtls_ssl_free
@@ -131,7 +133,7 @@ class SslSession internal constructor(
         if (mem.getInt(0) == 0) {
             return null
         }
-        val size = mem.getInt(8)
+        val size = mem.getSizeT(8).toInt()
 
         return mem.getByteArray(16, size)
     }
@@ -201,11 +203,10 @@ class SslSession internal constructor(
 
     fun saveAndClose(): ByteArray = use {
         val buffer = ByteArray(1280)
-        val outputLen = ByteArray(4)
-        mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
-
-        val size = (outputLen[0].toInt() and 0xff) + (outputLen[1].toInt() and 0xff shl 8)
-        buffer.copyOf(size)
+        allocateSizeT().use { outputLen ->
+            mbedtls_ssl_context_save(sslContext, buffer, buffer.size, outputLen).verify()
+            buffer.copyOf(outputLen.getSizeT(0).toInt())
+        }
     }
 
     override fun toString(): String = when {

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeTypesTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeTypesTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022-2026 kotlin-mbedtls contributors (https://github.com/open-coap/kotlin-mbedtls)
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opencoap.ssl
+
+import com.sun.jna.Memory
+import com.sun.jna.Native
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class NativeTypesTest {
+
+    @Test
+    fun `should match the platform size_t width`() {
+        // fails loudly if this library ever ships a native library for a 32 bit target
+        assertEquals(Native.SIZE_T_SIZE.toLong(), SIZE_T_LEN)
+    }
+
+    @Test
+    fun `should read size_t out-parameter`() {
+        Memory(SIZE_T_LEN).use { mem ->
+            mem.setLong(0, 1280)
+
+            assertEquals(1280, mem.getSizeT())
+        }
+    }
+
+    @Test
+    fun `should read size_t larger than the old two byte parse allowed`() {
+        Memory(SIZE_T_LEN).use { mem ->
+            mem.setLong(0, 70_000)
+
+            assertEquals(70_000, mem.getSizeT())
+        }
+    }
+
+    @Test
+    fun `should read size_t at given offset`() {
+        Memory(16).use { mem ->
+            mem.clear()
+            mem.setLong(8, 64)
+
+            assertEquals(0, mem.getSizeT())
+            assertEquals(64, mem.getSizeT(8))
+        }
+    }
+
+    @Test
+    fun `should read size_t in native byte order`() {
+        // the byte layout mbedtls writes for a size_t on this platform
+        val nativeBytes = ByteBuffer.allocate(SIZE_T_LEN.toInt())
+            .order(ByteOrder.nativeOrder())
+            .putLong(1280)
+            .array()
+
+        Memory(SIZE_T_LEN).use { mem ->
+            mem.write(0, nativeBytes, 0, nativeBytes.size)
+
+            assertEquals(1280, mem.getSizeT())
+        }
+    }
+}

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeTypesTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/NativeTypesTest.kt
@@ -28,12 +28,12 @@ class NativeTypesTest {
     @Test
     fun `should match the platform size_t width`() {
         // fails loudly if this library ever ships a native library for a 32 bit target
-        assertEquals(Native.SIZE_T_SIZE.toLong(), SIZE_T_LEN)
+        assertEquals(8, Native.SIZE_T_SIZE)
     }
 
     @Test
     fun `should read size_t out-parameter`() {
-        Memory(SIZE_T_LEN).use { mem ->
+        Memory(8).use { mem ->
             mem.setLong(0, 1280)
 
             assertEquals(1280, mem.getSizeT())
@@ -42,7 +42,7 @@ class NativeTypesTest {
 
     @Test
     fun `should read size_t larger than the old two byte parse allowed`() {
-        Memory(SIZE_T_LEN).use { mem ->
+        Memory(8).use { mem ->
             mem.setLong(0, 70_000)
 
             assertEquals(70_000, mem.getSizeT())
@@ -63,12 +63,12 @@ class NativeTypesTest {
     @Test
     fun `should read size_t in native byte order`() {
         // the byte layout mbedtls writes for a size_t on this platform
-        val nativeBytes = ByteBuffer.allocate(SIZE_T_LEN.toInt())
+        val nativeBytes = ByteBuffer.allocate(8)
             .order(ByteOrder.nativeOrder())
             .putLong(1280)
             .array()
 
-        Memory(SIZE_T_LEN).use { mem ->
+        Memory(8).use { mem ->
             mem.write(0, nativeBytes, 0, nativeBytes.size)
 
             assertEquals(1280, mem.getSizeT())


### PR DESCRIPTION
The JNA binding for `mbedtls_ssl_context_save` declared its `size_t*` output-length out-parameter as a 4-byte `ByteArray`, so every successful call wrote 8 bytes into a 4-byte allocation on 64-bit targets. The length was then read from two bytes, little-endian.

Binds it as a `Pointer` sized `Native.SIZE_T_SIZE` and reads it at native width and byte order. Same fix applied to `peerCidLen` in `mbedtls_ssl_get_peer_cid`.