### PR TITLE
fix(transport): bound-check the ClientHello extension walk

### DIFF
--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -409,23 +409,26 @@ class DtlsServer(
         return true
     }
 
+    // Walks a ClientHello looking for the connection_id extension. Every length here is
+    // attacker-controlled, so each step is bound-checked and a field running past the end of
+    // the datagram answers false rather than throwing out of the receive path. Inputs that
+    // parsed before are unaffected: each check triggers exactly where a read used to throw.
     private fun supportsCid(buf: ByteBuffer): Boolean {
         val workingBuffer = buf.slice().order(ByteOrder.BIG_ENDIAN)
 
         // Go to the start of extensions
-        workingBuffer
-            // Skip DTLSHeader(13) + HandshakeHeader(12) + SessionIDLengthOffset(34)
-            .seek(59)
-            // Skip variable-length Session ID
-            .readByteAndSeek()
-            // Skip variable-length Cookie
-            .readByteAndSeek()
-            // Skip variable-length CipherSuites
-            .readShortAndSeek()
-            // Skip variable-length CompressionMethods
-            .readByteAndSeek()
-            // Limit buffer to the length of the Extensions block
-            .readShortAndLimit()
+        // Skip DTLSHeader(13) + HandshakeHeader(12) + SessionIDLengthOffset(34)
+        if (!workingBuffer.trySeek(59)) return false
+        // Skip variable-length Session ID
+        if (!workingBuffer.trySkipByteLengthPrefixed()) return false
+        // Skip variable-length Cookie
+        if (!workingBuffer.trySkipByteLengthPrefixed()) return false
+        // Skip variable-length CipherSuites
+        if (!workingBuffer.trySkipShortLengthPrefixed()) return false
+        // Skip variable-length CompressionMethods
+        if (!workingBuffer.trySkipByteLengthPrefixed()) return false
+        // Limit buffer to the length of the Extensions block
+        if (!workingBuffer.tryLimitShortLengthPrefixed()) return false
 
         // Search for CID extension
         while (workingBuffer.remaining() >= 4) {
@@ -435,11 +438,41 @@ class DtlsServer(
             }
 
             // Skip to the next extension
-            workingBuffer.readShortAndSeek()
+            if (!workingBuffer.trySkipShortLengthPrefixed()) return false
         }
 
         return false
     }
+}
+
+// Bound-checked counterparts of the seek helpers below, for parsing attacker-controlled
+// lengths. Each returns false and leaves the buffer untouched when the field it describes
+// does not fit within the buffer's limit.
+private fun ByteBuffer.trySeek(offset: Int): Boolean {
+    if (remaining() < offset) return false
+    position(position() + offset)
+    return true
+}
+
+private fun ByteBuffer.trySkipByteLengthPrefixed(): Boolean {
+    if (remaining() < Byte.SIZE_BYTES) return false
+    val length = get(position()).toUByte().toInt()
+    return trySeek(Byte.SIZE_BYTES + length)
+}
+
+private fun ByteBuffer.trySkipShortLengthPrefixed(): Boolean {
+    if (remaining() < Short.SIZE_BYTES) return false
+    val length = getShort(position()).toUShort().toInt()
+    return trySeek(Short.SIZE_BYTES + length)
+}
+
+private fun ByteBuffer.tryLimitShortLengthPrefixed(): Boolean {
+    if (remaining() < Short.SIZE_BYTES) return false
+    val length = getShort(position()).toUShort().toInt()
+    if (remaining() - Short.SIZE_BYTES < length) return false
+    position(position() + Short.SIZE_BYTES)
+    limit(position() + length)
+    return true
 }
 
 fun ByteBuffer.seek(offset: Int): ByteBuffer = this.position(this.position() + offset) as ByteBuffer

--- a/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
+++ b/kotlin-mbedtls/src/main/kotlin/org/opencoap/ssl/transport/DtlsServer.kt
@@ -409,10 +409,8 @@ class DtlsServer(
         return true
     }
 
-    // Walks a ClientHello looking for the connection_id extension. Every length here is
-    // attacker-controlled, so each step is bound-checked and a field running past the end of
-    // the datagram answers false rather than throwing out of the receive path. Inputs that
-    // parsed before are unaffected: each check triggers exactly where a read used to throw.
+    // Lengths here are attacker-controlled, so every step is bound-checked: a field reaching
+    // past the end of the datagram answers false instead of throwing.
     private fun supportsCid(buf: ByteBuffer): Boolean {
         val workingBuffer = buf.slice().order(ByteOrder.BIG_ENDIAN)
 
@@ -445,9 +443,7 @@ class DtlsServer(
     }
 }
 
-// Bound-checked counterparts of the seek helpers below, for parsing attacker-controlled
-// lengths. Each returns false and leaves the buffer untouched when the field it describes
-// does not fit within the buffer's limit.
+// Bound-checked seeks. Each returns false, buffer untouched, when the field does not fit.
 private fun ByteBuffer.trySeek(offset: Int): Boolean {
     if (remaining() < offset) return false
     position(position() + offset)

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -341,6 +341,47 @@ class DtlsServerTest {
         assertEquals(0, dtlsServer.numberOfSessions)
     }
 
+    // supportsCid() walks a ClientHello from offset 59 through four attacker-controlled
+    // variable-length fields. The 14-byte guard in isValidHandshakeRequest is not enough to
+    // cover it, so before the bound checks every length in 14..65 that passed the header sniff
+    // threw out of handleReceived(): 14..58 on the seek to offset 59, 59..65 on the
+    // variable-length walk running off the end. The 0f73c72 fuzz test never caught this
+    // because it runs with cidRequired = false, which never reaches supportsCid.
+    @Test
+    fun `should drop short datagrams when CID is required`() {
+        dtlsServer = DtlsServer(::outboundTransport, serverConf, 100.millis, sessionStore::write, lifecycleCallbacks, executor = SingleThreadExecutor.create("dtls-srv-"), cidRequired = true)
+        val adr = localAddress(2_5684)
+
+        // passes the header sniff: Handshake(0x16), DTLS 1.2, epoch 0, ClientHello(1) at offset 13
+        val clientHelloHeader = "16fefd0000000000000000000001".decodeHex()
+
+        for (len in 0..120) {
+            val bytes = clientHelloHeader.copyOf(len.coerceAtMost(clientHelloHeader.size)) +
+                ByteArray((len - clientHelloHeader.size).coerceAtLeast(0))
+            val result = dtlsServer.handleReceived(adr, ByteBuffer.wrap(bytes))
+            assertTrue(result is ReceiveResult.Handled, "expected Handled for length $len, got $result")
+        }
+
+        assertEquals(0, dtlsServer.numberOfSessions)
+    }
+
+    @Test
+    fun `should not throw for randomised datagrams when CID is required`() {
+        dtlsServer = DtlsServer(::outboundTransport, serverConf, 100.millis, sessionStore::write, lifecycleCallbacks, executor = SingleThreadExecutor.create("dtls-srv-"), cidRequired = true)
+        val random = Random(1)
+        val adr = localAddress(2_5684)
+
+        repeat(20_000) {
+            // prefix half the datagrams with a valid-looking ClientHello header so the fuzz
+            // actually reaches the extension walk instead of being rejected by the sniff
+            val body = random.nextBytes(random.nextInt(0, 301))
+            val bytes = if (random.nextBoolean()) "16fefd0000000000000000000001".decodeHex() + body else body
+            dtlsServer.handleReceived(adr, ByteBuffer.wrap(bytes))
+        }
+
+        assertEquals(0, dtlsServer.numberOfSessions)
+    }
+
     private fun clientHandshake(): SslSession {
         val send: (ByteBuffer) -> Unit = { dtlsServer.handleReceived(localAddress(2_5684), it) }
         val cliHandshake = clientConf.newContext(localAddress(5684))

--- a/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
+++ b/kotlin-mbedtls/src/test/kotlin/org/opencoap/ssl/transport/DtlsServerTest.kt
@@ -341,18 +341,15 @@ class DtlsServerTest {
         assertEquals(0, dtlsServer.numberOfSessions)
     }
 
-    // supportsCid() walks a ClientHello from offset 59 through four attacker-controlled
-    // variable-length fields. The 14-byte guard in isValidHandshakeRequest is not enough to
-    // cover it, so before the bound checks every length in 14..65 that passed the header sniff
-    // threw out of handleReceived(): 14..58 on the seek to offset 59, 59..65 on the
-    // variable-length walk running off the end. The 0f73c72 fuzz test never caught this
-    // because it runs with cidRequired = false, which never reaches supportsCid.
+    // supportsCid() walks from offset 59, but isValidHandshakeRequest only guards 14 bytes.
+    // Before the bound checks, every length in 14..65 that passed the sniff threw out of
+    // handleReceived(). The 0f73c72 fuzz test runs with cidRequired = false, so it never hit this.
     @Test
     fun `should drop short datagrams when CID is required`() {
         dtlsServer = DtlsServer(::outboundTransport, serverConf, 100.millis, sessionStore::write, lifecycleCallbacks, executor = SingleThreadExecutor.create("dtls-srv-"), cidRequired = true)
         val adr = localAddress(2_5684)
 
-        // passes the header sniff: Handshake(0x16), DTLS 1.2, epoch 0, ClientHello(1) at offset 13
+        // passes the sniff: Handshake(0x16), DTLS 1.2, epoch 0, ClientHello(1) at offset 13
         val clientHelloHeader = "16fefd0000000000000000000001".decodeHex()
 
         for (len in 0..120) {
@@ -372,8 +369,7 @@ class DtlsServerTest {
         val adr = localAddress(2_5684)
 
         repeat(20_000) {
-            // prefix half the datagrams with a valid-looking ClientHello header so the fuzz
-            // actually reaches the extension walk instead of being rejected by the sniff
+            // half get a valid-looking header, so the fuzz reaches the walk instead of the sniff
             val body = random.nextBytes(random.nextInt(0, 301))
             val bytes = if (random.nextBoolean()) "16fefd0000000000000000000001".decodeHex() + body else body
             dtlsServer.handleReceived(adr, ByteBuffer.wrap(bytes))


### PR DESCRIPTION
With cidRequired = true, supportsCid() walks a ClientHello from offset 59 through four attacker-controlled variable-length fields, but the only guard before it is isValidHandshakeRequest's 14-byte check. Every unauthenticated datagram of length 14..65 that passed the header sniff threw out of handleReceived(): 14..58 on the seek to offset 59 (IllegalArgumentException), 59..65 on the variable-length walk (BufferUnderflowException).

0f73c72 hardened exactly this class of bug, but only for the default path -- the fuzz test it added runs with cidRequired = false, so it never reached supportsCid.

Impact is a logged exception with a stack trace per datagram rather than a dead server: 8d0df27 already made listen() survive non-transport exceptions, and on the netty path useAndRelease is try/finally so the ByteBuf is not leaked and the channel stays open. Still remotely spammable by an unauthenticated peer.

Each step of the walk is now bound-checked and answers false when a field runs past the end of the datagram, using explicit guards rather than catching buffer exceptions so no exception machinery runs on attacker-controlled input. Inputs that parsed before are unaffected: each check triggers exactly where a read used to throw.

The existing public seek helpers and their test are left untouched.